### PR TITLE
feat: migrate level to zone system

### DIFF
--- a/src/level.rs
+++ b/src/level.rs
@@ -40,9 +40,29 @@ impl Level {
     /// Enemy level equals `depth` (minimum 1).
     /// Surprise: 25% party ambushed, 25% enemy ambushed, 50% normal.
     pub fn generate(depth: u32, rng: &mut impl Rng) -> Self {
+        let biome = random_biome(rng);
+        Self::generate_inner(depth, biome, None, rng)
+    }
+
+    /// Generate a level with a specific biome and optional enemy pool (for zone-scoped encounters).
+    /// When `enemy_pool` is `None`, all enemy kinds are eligible.
+    pub fn generate_for_zone(
+        depth: u32,
+        biome: Biome,
+        enemy_pool: &[EnemyKind],
+        rng: &mut impl Rng,
+    ) -> Self {
+        Self::generate_inner(depth, biome, Some(enemy_pool), rng)
+    }
+
+    fn generate_inner(
+        depth: u32,
+        biome: Biome,
+        enemy_pool: Option<&[EnemyKind]>,
+        rng: &mut impl Rng,
+    ) -> Self {
         let cols: u32 = rng.gen_range(8..=16);
         let rows: u32 = rng.gen_range(8..=16);
-        let biome = random_biome(rng);
         let enemy_level = depth.max(1);
         let enemy_count: usize = rng.gen_range(1..=4);
 
@@ -52,7 +72,10 @@ impl Level {
             let x = rng.gen_range(0..cols as i32);
             let y = rng.gen_range(0..rows as i32);
             if used.insert((x, y)) {
-                let kind = random_enemy_kind(rng);
+                let kind = match enemy_pool {
+                    Some(pool) => pool[rng.gen_range(0..pool.len())].clone(),
+                    None => random_enemy_kind(rng),
+                };
                 enemies.push((Enemy::new(kind, enemy_level), Position::new(x, y, 0)));
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,4 @@ pub mod stats;
 pub mod terrain;
 pub mod turn;
 pub mod weapon;
+pub mod zone;

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -1,0 +1,219 @@
+use rand::Rng;
+use crate::enemy::EnemyKind;
+use crate::level::Level;
+use crate::terrain::Biome;
+
+/// One of the nine named zones in the Meridian station, as described in docs/world.md.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ZoneKind {
+    // Interior zones
+    ResearchWing,
+    CommandDeck,
+    MilitaryAnnex,
+    SystemsCore,
+    MedicalBay,
+    DockingBay,
+    // Exterior zones
+    StationExterior,
+    RelayArray,
+    ExcavationSite,
+}
+
+/// Whether a zone is inside the station or on the moon surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ZoneType {
+    Interior,
+    Exterior,
+}
+
+/// Adjacent zone for each cardinal direction, as defined in docs/world.md.
+///
+/// ```text
+///                          [Relay Array]
+///                                |N
+///           [Excavation Site]--W[Station Exterior]
+///                                     |S
+///              [Command Deck]--W[Docking Bay]--E[Military Annex]
+///                    |S               |S               |S
+///              [Research Wing]--E[Systems Core]--E[Medical Bay]
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct ZoneConnections {
+    pub north: Option<ZoneKind>,
+    pub south: Option<ZoneKind>,
+    pub east: Option<ZoneKind>,
+    pub west: Option<ZoneKind>,
+}
+
+impl ZoneConnections {
+    pub fn get(&self, dir: CardinalDir) -> Option<ZoneKind> {
+        match dir {
+            CardinalDir::North => self.north,
+            CardinalDir::South => self.south,
+            CardinalDir::East => self.east,
+            CardinalDir::West => self.west,
+        }
+    }
+}
+
+/// Cardinal direction used for zone navigation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardinalDir {
+    North,
+    South,
+    East,
+    West,
+}
+
+impl CardinalDir {
+    /// Returns the direction directly opposite to this one.
+    pub fn opposite(self) -> Self {
+        match self {
+            CardinalDir::North => CardinalDir::South,
+            CardinalDir::South => CardinalDir::North,
+            CardinalDir::East => CardinalDir::West,
+            CardinalDir::West => CardinalDir::East,
+        }
+    }
+}
+
+/// A zone in the Meridian station with a freshly generated encounter layout.
+///
+/// Call [`Zone::enter`] each time the player enters a zone to get a new random layout.
+#[derive(Debug)]
+pub struct Zone {
+    pub kind: ZoneKind,
+    pub connections: ZoneConnections,
+    pub level: Level,
+}
+
+impl Zone {
+    /// Enter a zone, procedurally generating a fresh encounter layout using
+    /// zone-appropriate biome and enemy types.
+    pub fn enter(kind: ZoneKind, depth: u32, rng: &mut impl Rng) -> Self {
+        let connections = zone_connections(kind);
+        let biome = kind.default_biome();
+        let enemy_pool = kind.enemy_pool();
+        let level = Level::generate_for_zone(depth, biome, enemy_pool, rng);
+        Self { kind, connections, level }
+    }
+}
+
+impl ZoneKind {
+    pub fn zone_type(self) -> ZoneType {
+        match self {
+            ZoneKind::StationExterior | ZoneKind::RelayArray | ZoneKind::ExcavationSite => {
+                ZoneType::Exterior
+            }
+            _ => ZoneType::Interior,
+        }
+    }
+
+    pub fn display_name(self) -> &'static str {
+        match self {
+            ZoneKind::ResearchWing => "Research Wing",
+            ZoneKind::CommandDeck => "Command Deck",
+            ZoneKind::MilitaryAnnex => "Military Annex",
+            ZoneKind::SystemsCore => "Systems Core",
+            ZoneKind::MedicalBay => "Medical Bay",
+            ZoneKind::DockingBay => "Docking Bay",
+            ZoneKind::StationExterior => "Station Exterior",
+            ZoneKind::RelayArray => "Relay Array",
+            ZoneKind::ExcavationSite => "Excavation Site",
+        }
+    }
+
+    /// The default terrain biome for encounters in this zone.
+    pub fn default_biome(self) -> Biome {
+        match self {
+            ZoneKind::ResearchWing => Biome::BioLab,
+            ZoneKind::CommandDeck => Biome::VoidStation,
+            ZoneKind::MilitaryAnnex => Biome::VoidStation,
+            ZoneKind::SystemsCore => Biome::VoidStation,
+            ZoneKind::MedicalBay => Biome::BioLab,
+            ZoneKind::DockingBay => Biome::NeonDistrict,
+            ZoneKind::StationExterior => Biome::AsteroidColony,
+            ZoneKind::RelayArray => Biome::AsteroidColony,
+            ZoneKind::ExcavationSite => Biome::AsteroidColony,
+        }
+    }
+
+    /// The set of enemy types that can spawn in encounters within this zone.
+    pub fn enemy_pool(self) -> &'static [EnemyKind] {
+        match self {
+            ZoneKind::ResearchWing => &[EnemyKind::MaintenanceDrone, EnemyKind::Scavenger],
+            ZoneKind::CommandDeck => &[EnemyKind::StationGuard, EnemyKind::SecurityUnit],
+            ZoneKind::MilitaryAnnex => &[EnemyKind::GunForHire, EnemyKind::ShockTrooper],
+            ZoneKind::SystemsCore => &[EnemyKind::MaintenanceDrone, EnemyKind::SecurityUnit],
+            ZoneKind::MedicalBay => &[EnemyKind::VoidSpitter, EnemyKind::StationGuard],
+            ZoneKind::DockingBay => &[
+                EnemyKind::Scavenger,
+                EnemyKind::VoidRaider,
+                EnemyKind::DrifterBoss,
+            ],
+            ZoneKind::StationExterior => &[
+                EnemyKind::MoonCrawler,
+                EnemyKind::VoidRaider,
+                EnemyKind::AbyssalBrute,
+            ],
+            ZoneKind::RelayArray => &[EnemyKind::VoidRaider, EnemyKind::DrifterBoss],
+            ZoneKind::ExcavationSite => &[
+                EnemyKind::MoonCrawler,
+                EnemyKind::VoidSpitter,
+                EnemyKind::AbyssalBrute,
+            ],
+        }
+    }
+}
+
+/// Returns the cardinal connections for the given zone as specified in docs/world.md.
+pub fn zone_connections(kind: ZoneKind) -> ZoneConnections {
+    match kind {
+        ZoneKind::ResearchWing => ZoneConnections {
+            north: Some(ZoneKind::CommandDeck),
+            east: Some(ZoneKind::SystemsCore),
+            ..Default::default()
+        },
+        ZoneKind::CommandDeck => ZoneConnections {
+            south: Some(ZoneKind::ResearchWing),
+            east: Some(ZoneKind::DockingBay),
+            ..Default::default()
+        },
+        ZoneKind::MilitaryAnnex => ZoneConnections {
+            west: Some(ZoneKind::DockingBay),
+            south: Some(ZoneKind::MedicalBay),
+            ..Default::default()
+        },
+        ZoneKind::SystemsCore => ZoneConnections {
+            west: Some(ZoneKind::ResearchWing),
+            east: Some(ZoneKind::MedicalBay),
+            north: Some(ZoneKind::DockingBay),
+            ..Default::default()
+        },
+        ZoneKind::MedicalBay => ZoneConnections {
+            north: Some(ZoneKind::MilitaryAnnex),
+            west: Some(ZoneKind::SystemsCore),
+            ..Default::default()
+        },
+        ZoneKind::DockingBay => ZoneConnections {
+            north: Some(ZoneKind::StationExterior),
+            east: Some(ZoneKind::MilitaryAnnex),
+            west: Some(ZoneKind::CommandDeck),
+            south: Some(ZoneKind::SystemsCore),
+        },
+        ZoneKind::StationExterior => ZoneConnections {
+            north: Some(ZoneKind::RelayArray),
+            south: Some(ZoneKind::DockingBay),
+            west: Some(ZoneKind::ExcavationSite),
+            ..Default::default()
+        },
+        ZoneKind::RelayArray => ZoneConnections {
+            south: Some(ZoneKind::StationExterior),
+            ..Default::default()
+        },
+        ZoneKind::ExcavationSite => ZoneConnections {
+            east: Some(ZoneKind::StationExterior),
+            ..Default::default()
+        },
+    }
+}

--- a/tests/zone_tests.rs
+++ b/tests/zone_tests.rs
@@ -1,0 +1,183 @@
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use carbonthrone::zone::{CardinalDir, ZoneKind, ZoneType, zone_connections};
+
+fn rng() -> StdRng {
+    StdRng::seed_from_u64(42)
+}
+
+// ── Connection topology ───────────────────────────────────────────────────────
+
+#[test]
+fn connections_are_symmetric() {
+    // For every A --dir--> B, B must connect back to A via the opposite direction.
+    let all_zones = [
+        ZoneKind::ResearchWing,
+        ZoneKind::CommandDeck,
+        ZoneKind::MilitaryAnnex,
+        ZoneKind::SystemsCore,
+        ZoneKind::MedicalBay,
+        ZoneKind::DockingBay,
+        ZoneKind::StationExterior,
+        ZoneKind::RelayArray,
+        ZoneKind::ExcavationSite,
+    ];
+    let dirs = [
+        CardinalDir::North,
+        CardinalDir::South,
+        CardinalDir::East,
+        CardinalDir::West,
+    ];
+    for &zone in &all_zones {
+        let conns = zone_connections(zone);
+        for &dir in &dirs {
+            if let Some(neighbor) = conns.get(dir) {
+                let neighbor_conns = zone_connections(neighbor);
+                let back = neighbor_conns.get(dir.opposite());
+                assert_eq!(
+                    back,
+                    Some(zone),
+                    "{:?} --{:?}--> {:?}, but {:?} does not connect back via {:?}",
+                    zone, dir, neighbor, neighbor, dir.opposite()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn research_wing_connects_north_to_command_deck() {
+    let conns = zone_connections(ZoneKind::ResearchWing);
+    assert_eq!(conns.north, Some(ZoneKind::CommandDeck));
+}
+
+#[test]
+fn research_wing_connects_east_to_systems_core() {
+    let conns = zone_connections(ZoneKind::ResearchWing);
+    assert_eq!(conns.east, Some(ZoneKind::SystemsCore));
+}
+
+#[test]
+fn docking_bay_has_four_connections() {
+    let conns = zone_connections(ZoneKind::DockingBay);
+    assert_eq!(conns.north, Some(ZoneKind::StationExterior));
+    assert_eq!(conns.east, Some(ZoneKind::MilitaryAnnex));
+    assert_eq!(conns.west, Some(ZoneKind::CommandDeck));
+    assert_eq!(conns.south, Some(ZoneKind::SystemsCore));
+}
+
+#[test]
+fn relay_array_only_connects_south() {
+    let conns = zone_connections(ZoneKind::RelayArray);
+    assert_eq!(conns.south, Some(ZoneKind::StationExterior));
+    assert!(conns.north.is_none());
+    assert!(conns.east.is_none());
+    assert!(conns.west.is_none());
+}
+
+#[test]
+fn excavation_site_only_connects_east() {
+    let conns = zone_connections(ZoneKind::ExcavationSite);
+    assert_eq!(conns.east, Some(ZoneKind::StationExterior));
+    assert!(conns.north.is_none());
+    assert!(conns.south.is_none());
+    assert!(conns.west.is_none());
+}
+
+// ── Zone types ────────────────────────────────────────────────────────────────
+
+#[test]
+fn interior_zones_have_correct_type() {
+    let interiors = [
+        ZoneKind::ResearchWing,
+        ZoneKind::CommandDeck,
+        ZoneKind::MilitaryAnnex,
+        ZoneKind::SystemsCore,
+        ZoneKind::MedicalBay,
+        ZoneKind::DockingBay,
+    ];
+    for zone in interiors {
+        assert_eq!(zone.zone_type(), ZoneType::Interior, "{:?} should be Interior", zone);
+    }
+}
+
+#[test]
+fn exterior_zones_have_correct_type() {
+    let exteriors = [
+        ZoneKind::StationExterior,
+        ZoneKind::RelayArray,
+        ZoneKind::ExcavationSite,
+    ];
+    for zone in exteriors {
+        assert_eq!(zone.zone_type(), ZoneType::Exterior, "{:?} should be Exterior", zone);
+    }
+}
+
+// ── Zone encounter generation ─────────────────────────────────────────────────
+
+#[test]
+fn zone_enter_generates_encounter_with_enemies() {
+    use carbonthrone::zone::Zone;
+    let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut rng());
+    assert!(!zone.level.enemies.is_empty());
+}
+
+#[test]
+fn zone_enter_enemies_come_from_zone_pool() {
+    use carbonthrone::zone::Zone;
+    let mut r = rng();
+    for _ in 0..20 {
+        let zone = Zone::enter(ZoneKind::ResearchWing, 1, &mut r);
+        let pool = ZoneKind::ResearchWing.enemy_pool();
+        for (enemy, _) in &zone.level.enemies {
+            assert!(
+                pool.contains(&enemy.kind),
+                "ResearchWing spawned unexpected enemy kind: {:?}",
+                enemy.kind
+            );
+        }
+    }
+}
+
+#[test]
+fn zone_kind_stored_on_zone() {
+    use carbonthrone::zone::Zone;
+    let zone = Zone::enter(ZoneKind::RelayArray, 3, &mut rng());
+    assert_eq!(zone.kind, ZoneKind::RelayArray);
+}
+
+#[test]
+fn zone_connections_stored_on_zone() {
+    use carbonthrone::zone::Zone;
+    let zone = Zone::enter(ZoneKind::RelayArray, 1, &mut rng());
+    assert_eq!(zone.connections.south, Some(ZoneKind::StationExterior));
+}
+
+#[test]
+fn enemy_level_matches_depth_in_zone() {
+    use carbonthrone::zone::Zone;
+    let depth = 4;
+    let zone = Zone::enter(ZoneKind::MilitaryAnnex, depth, &mut rng());
+    assert!(zone.level.enemies.iter().all(|(e, _)| e.level == depth));
+}
+
+#[test]
+fn all_zones_can_be_entered() {
+    use carbonthrone::zone::Zone;
+    let all_zones = [
+        ZoneKind::ResearchWing,
+        ZoneKind::CommandDeck,
+        ZoneKind::MilitaryAnnex,
+        ZoneKind::SystemsCore,
+        ZoneKind::MedicalBay,
+        ZoneKind::DockingBay,
+        ZoneKind::StationExterior,
+        ZoneKind::RelayArray,
+        ZoneKind::ExcavationSite,
+    ];
+    let mut r = rng();
+    for kind in all_zones {
+        let zone = Zone::enter(kind, 1, &mut r);
+        assert!(!zone.level.enemies.is_empty(), "{:?} produced no enemies", kind);
+    }
+}


### PR DESCRIPTION
Implements the zone system requested in #2.

Adds `zone.rs` defining all 9 Meridian station zones with cardinal connections matching `docs/world.md`. Each zone has a zone-appropriate biome and enemy pool; `Zone::enter()` generates a random encounter layout on entry. `Level::generate` remains backward-compatible.

Closes #2

Generated with [Claude Code](https://claude.ai/code)