### PR TITLE
feat: add dialog system driven by loop YAML scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,8 @@ dependencies = [
  "bevy",
  "crossterm",
  "rand 0.8.5",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -4273,6 +4275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4365,6 +4373,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4882,6 +4903,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2024"
 bevy = "0.18.1"
 crossterm = "0.27"
 rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1,0 +1,205 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::Deserialize;
+
+/// Which companion is required to be active for a scene to trigger.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Companion {
+    Any,
+    Orin,
+    Doss,
+    Kaleo,
+}
+
+/// The in-world event that fires a scene.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Trigger {
+    OnEnter,
+    OnCombatEnd,
+    OnInteract,
+    OnChoice,
+}
+
+/// Conditions that must hold for a scene to be shown.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SceneRequires {
+    pub companion: Companion,
+    #[serde(default)]
+    pub flags_set: Vec<String>,
+    #[serde(default)]
+    pub flags_unset: Vec<String>,
+}
+
+/// A single line of spoken dialog.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DialogLine {
+    pub speaker: String,
+    pub text: String,
+    pub emotion: String,
+}
+
+/// A player-selectable option at the end of a scene.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Choice {
+    pub text: String,
+    pub leads_to: Option<String>,
+    #[serde(default)]
+    pub sets_flag: Option<String>,
+}
+
+/// A self-contained dialog scene loaded from a loop YAML file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Scene {
+    pub id: String,
+    pub location: String,
+    pub trigger: Trigger,
+    pub requires: SceneRequires,
+    pub lines: Vec<DialogLine>,
+    #[serde(default)]
+    pub choices: Option<Vec<Choice>>,
+    pub sets_flag: Option<String>,
+}
+
+/// Top-level structure of a loop YAML file (private; only scenes are exposed).
+#[derive(Debug, Deserialize)]
+struct DialogScript {
+    #[allow(dead_code)]
+    #[serde(rename = "loop")]
+    loop_num: u8,
+    scenes: Vec<Scene>,
+}
+
+/// Runtime dialog state machine.
+///
+/// Load one or more loop YAML scripts, then use [`DialogEngine::trigger`] to
+/// fire scenes by event and location.  Player choices are resolved with
+/// [`DialogEngine::select_choice`].  Flag state is kept here and checked
+/// automatically when evaluating scene requirements.
+#[derive(Debug, Default)]
+pub struct DialogEngine {
+    scenes: HashMap<String, Scene>,
+    flags: HashSet<String>,
+    current_scene: Option<String>,
+    active_companion: Option<String>,
+}
+
+impl DialogEngine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Parse a YAML string and register all its scenes.
+    pub fn load_script(&mut self, yaml: &str) -> Result<(), serde_yaml::Error> {
+        let script: DialogScript = serde_yaml::from_str(yaml)?;
+        for scene in script.scenes {
+            self.scenes.insert(scene.id.clone(), scene);
+        }
+        Ok(())
+    }
+
+    /// Set which companion is currently travelling with the player.
+    /// Pass `"orin"`, `"doss"`, or `"kaleo"` (case-insensitive stored as-is).
+    pub fn set_companion(&mut self, companion: impl Into<String>) {
+        self.active_companion = Some(companion.into());
+    }
+
+    /// Manually raise a flag (also done automatically by scenes and choices).
+    pub fn set_flag(&mut self, flag: impl Into<String>) {
+        self.flags.insert(flag.into());
+    }
+
+    /// Returns `true` when the named flag has been raised.
+    pub fn is_flag_set(&self, flag: &str) -> bool {
+        self.flags.contains(flag)
+    }
+
+    /// Return the currently active scene, if any.
+    pub fn current_scene(&self) -> Option<&Scene> {
+        self.current_scene.as_ref().and_then(|id| self.scenes.get(id))
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────
+
+    fn companion_matches(active: &Option<String>, required: &Companion) -> bool {
+        match required {
+            Companion::Any => true,
+            Companion::Orin => active.as_deref() == Some("orin"),
+            Companion::Doss => active.as_deref() == Some("doss"),
+            Companion::Kaleo => active.as_deref() == Some("kaleo"),
+        }
+    }
+
+    fn scene_available(scene: &Scene, flags: &HashSet<String>, active_companion: &Option<String>) -> bool {
+        let req = &scene.requires;
+        if !Self::companion_matches(active_companion, &req.companion) {
+            return false;
+        }
+        req.flags_set.iter().all(|f| flags.contains(f))
+            && req.flags_unset.iter().all(|f| !flags.contains(f))
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────
+
+    /// Find and activate the first available scene that matches the given
+    /// `trigger` and `location`.  Applies the scene's `sets_flag` if present.
+    /// Returns `None` when no matching scene passes its requirements.
+    pub fn trigger(&mut self, trigger: &Trigger, location: &str) -> Option<&Scene> {
+        let scene_id = {
+            let flags = &self.flags;
+            let companion = &self.active_companion;
+            self.scenes
+                .values()
+                .find(|s| {
+                    &s.trigger == trigger
+                        && s.location == location
+                        && Self::scene_available(s, flags, companion)
+                })
+                .map(|s| s.id.clone())?
+        };
+
+        self.activate_scene(scene_id)
+    }
+
+    /// Jump directly to a scene by id (e.g. after resolving a `leads_to`).
+    /// Returns `None` if the scene does not exist or its requirements are unmet.
+    pub fn go_to_scene(&mut self, scene_id: &str) -> Option<&Scene> {
+        let id = scene_id.to_string();
+        let available = self.scenes.get(&id).map(|s| {
+            Self::scene_available(s, &self.flags, &self.active_companion)
+        })?;
+        if !available {
+            return None;
+        }
+        self.activate_scene(id)
+    }
+
+    /// Resolve the choice at `choice_index` in the current scene.
+    /// Applies the choice's `sets_flag` and navigates to `leads_to` if set.
+    /// Returns the destination scene, or `None` when `leads_to` is absent.
+    pub fn select_choice(&mut self, choice_index: usize) -> Option<&Scene> {
+        let scene_id = self.current_scene.clone()?;
+        let (flag_to_set, next_id) = {
+            let scene = self.scenes.get(&scene_id)?;
+            let choices = scene.choices.as_ref()?;
+            let choice = choices.get(choice_index)?;
+            (choice.sets_flag.clone(), choice.leads_to.clone())
+        };
+
+        if let Some(flag) = flag_to_set {
+            self.flags.insert(flag);
+        }
+
+        let next_id = next_id?;
+        self.go_to_scene(&next_id)
+    }
+
+    fn activate_scene(&mut self, scene_id: String) -> Option<&Scene> {
+        if let Some(flag) = self.scenes.get(&scene_id)?.sets_flag.clone() {
+            self.flags.insert(flag);
+        }
+        self.current_scene = Some(scene_id.clone());
+        self.scenes.get(&scene_id)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod action_points;
+pub mod dialog;
 pub mod character;
 pub mod combat;
 pub mod enemy;

--- a/tests/dialog_tests.rs
+++ b/tests/dialog_tests.rs
@@ -1,0 +1,201 @@
+use carbonthrone::dialog::{DialogEngine, Trigger};
+
+const LOOP1_YAML: &str = include_str!("../docs/loops/loop1.yaml");
+const LOOP2_YAML: &str = include_str!("../docs/loops/loop2.yaml");
+
+// ── Loading ───────────────────────────────────────────────────────────────
+
+#[test]
+fn load_loop1_parses_without_error() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).expect("loop1 should parse");
+}
+
+#[test]
+fn load_multiple_loops() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).expect("loop1 should parse");
+    engine.load_script(LOOP2_YAML).expect("loop2 should parse");
+}
+
+// ── Triggering scenes ─────────────────────────────────────────────────────
+
+#[test]
+fn opening_scene_fires_on_enter() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("orin");
+
+    let scene = engine.trigger(&Trigger::OnEnter, "research_wing_room_7c");
+    assert!(scene.is_some());
+    let scene = scene.unwrap();
+    assert_eq!(scene.id, "loop1_opening");
+    assert!(!scene.lines.is_empty());
+}
+
+#[test]
+fn no_scene_for_unknown_location() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+
+    let scene = engine.trigger(&Trigger::OnEnter, "nowhere");
+    assert!(scene.is_none());
+}
+
+// ── Flag management ───────────────────────────────────────────────────────
+
+#[test]
+fn set_flag_and_is_flag_set() {
+    let mut engine = DialogEngine::new();
+    assert!(!engine.is_flag_set("companion_orin"));
+    engine.set_flag("companion_orin");
+    assert!(engine.is_flag_set("companion_orin"));
+}
+
+#[test]
+fn scene_sets_flag_automatically() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP2_YAML).unwrap();
+    engine.set_companion("orin");
+
+    // loop2_orin_locket requires companion_orin and flags_unset: [orin_locket_noticed]
+    // and it sets_flag: orin_locket_noticed
+    engine.set_flag("companion_orin");
+    assert!(!engine.is_flag_set("orin_locket_noticed"));
+
+    let scene = engine.trigger(&Trigger::OnInteract, "command_deck");
+    assert!(scene.is_some());
+    assert_eq!(scene.unwrap().id, "loop2_orin_locket");
+    assert!(engine.is_flag_set("orin_locket_noticed"));
+}
+
+// ── Requirements: flags_set / flags_unset ─────────────────────────────────
+
+#[test]
+fn scene_blocked_when_required_flag_absent() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("orin");
+
+    // loop1_post_split_orin requires flags_set: [companion_orin]
+    // Without that flag it should not fire.
+    let scene = engine.trigger(&Trigger::OnEnter, "command_deck");
+    assert!(scene.is_none());
+}
+
+#[test]
+fn scene_available_when_required_flag_set() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("orin");
+    engine.set_flag("companion_orin");
+
+    let scene = engine.trigger(&Trigger::OnEnter, "command_deck");
+    assert!(scene.is_some());
+    assert_eq!(scene.unwrap().id, "loop1_post_split_orin");
+}
+
+#[test]
+fn scene_blocked_when_unset_flag_is_present() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP2_YAML).unwrap();
+    engine.set_companion("orin");
+    engine.set_flag("companion_orin");
+    // orin_locket_noticed being set should block loop2_orin_locket
+    engine.set_flag("orin_locket_noticed");
+
+    let scene = engine.trigger(&Trigger::OnInteract, "command_deck");
+    assert!(scene.is_none());
+}
+
+// ── Companion requirements ────────────────────────────────────────────────
+
+#[test]
+fn scene_blocked_by_wrong_companion() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("doss");          // wrong companion
+    engine.set_flag("companion_orin");
+
+    let scene = engine.trigger(&Trigger::OnEnter, "command_deck");
+    assert!(scene.is_none());
+}
+
+// ── Choices ───────────────────────────────────────────────────────────────
+
+#[test]
+fn selecting_choice_sets_flag_and_navigates() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("orin");
+
+    // Trigger the split scene which has [Follow Orin.] / [Follow Doss.]
+    let scene = engine.trigger(&Trigger::OnEnter, "research_wing_corridor");
+    assert!(scene.is_some());
+    assert_eq!(scene.unwrap().id, "loop1_split");
+
+    // Select choice 0: [Follow Orin.] → sets companion_orin, leads_to loop1_post_split_orin
+    let next = engine.select_choice(0);
+    assert!(next.is_some());
+    assert_eq!(next.unwrap().id, "loop1_post_split_orin");
+    assert!(engine.is_flag_set("companion_orin"));
+}
+
+#[test]
+fn selecting_choice_with_null_leads_to_returns_none() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("doss");
+    engine.set_flag("companion_doss");
+
+    // loop1_doss_armory choice 1: "[Take equipment and move on.]" leads_to: ~
+    let scene = engine.trigger(&Trigger::OnEnter, "military_annex_armory");
+    assert!(scene.is_some());
+    assert_eq!(scene.unwrap().id, "loop1_doss_armory");
+
+    let next = engine.select_choice(1);
+    assert!(next.is_none());
+}
+
+#[test]
+fn out_of_bounds_choice_index_returns_none() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("orin");
+
+    engine.trigger(&Trigger::OnEnter, "research_wing_corridor");
+    let next = engine.select_choice(99);
+    assert!(next.is_none());
+}
+
+// ── go_to_scene ───────────────────────────────────────────────────────────
+
+#[test]
+fn go_to_scene_navigates_when_requirements_met() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("orin");
+    engine.set_flag("companion_orin");
+
+    let scene = engine.go_to_scene("loop1_orin_briefing");
+    assert!(scene.is_some());
+    assert_eq!(scene.unwrap().id, "loop1_orin_briefing");
+}
+
+#[test]
+fn go_to_scene_blocked_when_requirements_unmet() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+    engine.set_companion("doss");
+
+    let scene = engine.go_to_scene("loop1_orin_briefing");
+    assert!(scene.is_none());
+}
+
+#[test]
+fn go_to_unknown_scene_returns_none() {
+    let mut engine = DialogEngine::new();
+    engine.load_script(LOOP1_YAML).unwrap();
+
+    assert!(engine.go_to_scene("does_not_exist").is_none());
+}


### PR DESCRIPTION
Implements a `dialog` module that parses the companion YAML scripts in `docs/loops/`, evaluates scene requirements (companion, flags_set, flags_unset), fires scenes by trigger + location, manages flag state, and resolves player choices including flag-setting side effects.

Adds serde + serde_yaml dependencies for YAML deserialization and 16 integration tests covering loading, triggering, flag management, companion filtering, and choice navigation.

Closes #3

Generated with [Claude Code](https://claude.ai/code)