### PR TITLE
feat: combat encounter before exploration on zone entry

### DIFF
--- a/src/zone.rs
+++ b/src/zone.rs
@@ -77,25 +77,48 @@ impl CardinalDir {
     }
 }
 
+/// Probability that a combat encounter is generated when entering a zone.
+/// At 0.75, three out of four zone entries trigger a fight.
+pub const ENCOUNTER_CHANCE: f64 = 0.75;
+
 /// A zone in the Meridian station with a freshly generated encounter layout.
 ///
 /// Call [`Zone::enter`] each time the player enters a zone to get a new random layout.
+/// Combat happens before exploration: if `encounter` is `Some`, the party must resolve
+/// that fight before NPCs phase-shift in. Use [`Zone::npcs_available`] to check
+/// whether NPCs should appear.
 #[derive(Debug)]
 pub struct Zone {
     pub kind: ZoneKind,
     pub connections: ZoneConnections,
-    pub level: Level,
+    /// `Some` when a combat encounter was rolled on entry; `None` for a clear zone.
+    pub encounter: Option<Level>,
 }
 
 impl Zone {
-    /// Enter a zone, procedurally generating a fresh encounter layout using
-    /// zone-appropriate biome and enemy types.
+    /// Enter a zone, rolling for a random combat encounter first.
+    ///
+    /// There is an [`ENCOUNTER_CHANCE`] probability that enemies are generated
+    /// using zone-appropriate biome and enemy types. NPCs only phase-shift in
+    /// after the encounter is resolved (or immediately when there is none).
     pub fn enter(kind: ZoneKind, depth: u32, rng: &mut impl Rng) -> Self {
         let connections = zone_connections(kind);
-        let biome = kind.default_biome();
-        let enemy_pool = kind.enemy_pool();
-        let level = Level::generate_for_zone(depth, biome, enemy_pool, rng);
-        Self { kind, connections, level }
+        let encounter = if rng.gen::<f64>() < ENCOUNTER_CHANCE {
+            let biome = kind.default_biome();
+            let enemy_pool = kind.enemy_pool();
+            Some(Level::generate_for_zone(depth, biome, enemy_pool, rng))
+        } else {
+            None
+        };
+        Self { kind, connections, encounter }
+    }
+
+    /// Returns `true` when NPCs may phase-shift into the zone.
+    ///
+    /// NPCs are held back during an active combat encounter and become
+    /// available only once the encounter is cleared (or when there was none).
+    pub fn npcs_available(&self, encounter_cleared: bool) -> bool {
+        self.encounter.is_none() || encounter_cleared
     }
 }
 

--- a/tests/zone_tests.rs
+++ b/tests/zone_tests.rs
@@ -116,25 +116,50 @@ fn exterior_zones_have_correct_type() {
 // ── Zone encounter generation ─────────────────────────────────────────────────
 
 #[test]
-fn zone_enter_generates_encounter_with_enemies() {
+fn zone_enter_can_produce_encounter() {
     use carbonthrone::zone::Zone;
-    let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut rng());
-    assert!(!zone.level.enemies.is_empty());
+    let mut r = rng();
+    let found = (0..50).any(|_| Zone::enter(ZoneKind::DockingBay, 1, &mut r).encounter.is_some());
+    assert!(found, "expected at least one encounter in 50 attempts");
+}
+
+#[test]
+fn zone_enter_can_skip_encounter() {
+    use carbonthrone::zone::Zone;
+    let mut r = rng();
+    let found = (0..50).any(|_| Zone::enter(ZoneKind::DockingBay, 1, &mut r).encounter.is_none());
+    assert!(found, "expected at least one zone without encounter in 50 attempts");
+}
+
+#[test]
+fn zone_enter_encounter_has_enemies() {
+    use carbonthrone::zone::Zone;
+    let mut r = rng();
+    for _ in 0..50 {
+        let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut r);
+        if let Some(level) = &zone.encounter {
+            assert!(!level.enemies.is_empty(), "encounter had no enemies");
+            return;
+        }
+    }
+    panic!("could not find zone with encounter in 50 attempts");
 }
 
 #[test]
 fn zone_enter_enemies_come_from_zone_pool() {
     use carbonthrone::zone::Zone;
     let mut r = rng();
-    for _ in 0..20 {
+    let pool = ZoneKind::ResearchWing.enemy_pool();
+    for _ in 0..50 {
         let zone = Zone::enter(ZoneKind::ResearchWing, 1, &mut r);
-        let pool = ZoneKind::ResearchWing.enemy_pool();
-        for (enemy, _) in &zone.level.enemies {
-            assert!(
-                pool.contains(&enemy.kind),
-                "ResearchWing spawned unexpected enemy kind: {:?}",
-                enemy.kind
-            );
+        if let Some(level) = &zone.encounter {
+            for (enemy, _) in &level.enemies {
+                assert!(
+                    pool.contains(&enemy.kind),
+                    "ResearchWing spawned unexpected enemy kind: {:?}",
+                    enemy.kind
+                );
+            }
         }
     }
 }
@@ -157,8 +182,15 @@ fn zone_connections_stored_on_zone() {
 fn enemy_level_matches_depth_in_zone() {
     use carbonthrone::zone::Zone;
     let depth = 4;
-    let zone = Zone::enter(ZoneKind::MilitaryAnnex, depth, &mut rng());
-    assert!(zone.level.enemies.iter().all(|(e, _)| e.level == depth));
+    let mut r = rng();
+    for _ in 0..50 {
+        let zone = Zone::enter(ZoneKind::MilitaryAnnex, depth, &mut r);
+        if let Some(level) = &zone.encounter {
+            assert!(level.enemies.iter().all(|(e, _)| e.level == depth));
+            return;
+        }
+    }
+    panic!("could not find zone with encounter in 50 attempts");
 }
 
 #[test]
@@ -178,6 +210,50 @@ fn all_zones_can_be_entered() {
     let mut r = rng();
     for kind in all_zones {
         let zone = Zone::enter(kind, 1, &mut r);
-        assert!(!zone.level.enemies.is_empty(), "{:?} produced no enemies", kind);
+        assert_eq!(zone.kind, kind, "{:?} zone was not created correctly", kind);
     }
+}
+
+// ── NPC phase-shift logic ─────────────────────────────────────────────────────
+
+#[test]
+fn npcs_available_when_no_encounter() {
+    use carbonthrone::zone::Zone;
+    let mut r = rng();
+    for _ in 0..50 {
+        let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut r);
+        if zone.encounter.is_none() {
+            assert!(zone.npcs_available(false), "NPCs should be available with no encounter");
+            return;
+        }
+    }
+    panic!("could not find zone without encounter in 50 attempts");
+}
+
+#[test]
+fn npcs_not_available_during_active_encounter() {
+    use carbonthrone::zone::Zone;
+    let mut r = rng();
+    for _ in 0..50 {
+        let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut r);
+        if zone.encounter.is_some() {
+            assert!(!zone.npcs_available(false), "NPCs should be hidden during an active encounter");
+            return;
+        }
+    }
+    panic!("could not find zone with encounter in 50 attempts");
+}
+
+#[test]
+fn npcs_available_after_encounter_cleared() {
+    use carbonthrone::zone::Zone;
+    let mut r = rng();
+    for _ in 0..50 {
+        let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut r);
+        if zone.encounter.is_some() {
+            assert!(zone.npcs_available(true), "NPCs should phase-shift in after encounter is cleared");
+            return;
+        }
+    }
+    panic!("could not find zone with encounter in 50 attempts");
 }


### PR DESCRIPTION
When entering a zone, Zone::enter now rolls a 75% chance for a combat encounter.

Changes:
- `Zone.level` replaced by `encounter: Option<Level>`: Some = fight required, None = clear zone
- Added `ENCOUNTER_CHANCE: f64 = 0.75` constant
- Added `Zone::npcs_available(encounter_cleared)` for NPC phase-shift rule
- Updated and expanded zone tests including NPC phase-shift tests

Closes #8

Generated with [Claude Code](https://claude.ai/code)