### PR TITLE
Add player combat control with action choices and hit probability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod experience;
 pub mod health;
 pub mod level;
 pub mod party;
+pub mod player_input;
 pub mod position;
 pub mod side;
 pub mod simulation;

--- a/src/player_input.rs
+++ b/src/player_input.rs
@@ -1,0 +1,185 @@
+use std::collections::HashSet;
+
+use bevy::prelude::*;
+
+use crate::{
+    action_points::ActionPoints,
+    combat::{calc_damage, calc_hit_chance},
+    health::Health,
+    position::Position,
+    side::Side,
+    stats::Stats,
+    terrain::{CoverLevel, Direction, LevelMap},
+    turn::{Action, ATTACK_AP_COST, MOVE_AP_COST},
+};
+
+/// A fully-described action a player can choose for one of their combatants.
+#[derive(Debug, Clone)]
+pub enum PlayerActionChoice {
+    /// Attack a living enemy.
+    Attack {
+        target: Entity,
+        /// Probability of hitting, 0.0–1.0 (multiply by 100 for a percentage).
+        hit_chance: f32,
+        /// Damage dealt on a successful hit.
+        damage: i32,
+        /// Defender's cover level from this attack's direction.
+        cover: CoverLevel,
+    },
+    /// Move toward a tile offering better cover than the current position.
+    MoveToCover {
+        destination: Position,
+        /// Cover level the destination provides against the nearest enemy.
+        cover: CoverLevel,
+        /// Total AP cost (Manhattan distance × `MOVE_AP_COST`).
+        ap_cost: i32,
+    },
+    /// End this actor's turn without spending more AP.
+    Pass,
+}
+
+impl PlayerActionChoice {
+    /// Convert to the low-level [`Action`] consumed by [`crate::turn::apply_action`].
+    pub fn to_action(&self) -> Action {
+        match self {
+            Self::Attack { target, .. } => Action::Attack { target: *target },
+            Self::MoveToCover { destination, .. } => Action::Move { destination: *destination },
+            Self::Pass => Action::Pass,
+        }
+    }
+
+    /// Short human-readable label suitable for a menu entry.
+    pub fn display(&self) -> String {
+        match self {
+            Self::Attack { hit_chance, damage, cover, .. } => {
+                let pct = (hit_chance * 100.0).round() as i32;
+                match cover {
+                    CoverLevel::None    => format!("Attack — {}% hit, {} dmg", pct, damage),
+                    CoverLevel::Partial => format!("Attack — {}% hit, {} dmg (partial cover)", pct, damage),
+                    CoverLevel::Full    => format!("Attack — {}% hit, {} dmg (full cover)", pct, damage),
+                }
+            }
+            Self::MoveToCover { cover, ap_cost, .. } => {
+                let label = match cover {
+                    CoverLevel::None    => "open ground",
+                    CoverLevel::Partial => "partial cover",
+                    CoverLevel::Full    => "full cover",
+                };
+                format!("Move to {} (costs {} AP)", label, ap_cost)
+            }
+            Self::Pass => "Pass".to_string(),
+        }
+    }
+}
+
+/// Returns all valid actions available to `actor` this turn given their remaining AP.
+///
+/// Choices are grouped as follows:
+/// 1. One [`PlayerActionChoice::Attack`] per living enemy, each annotated with hit
+///    probability and expected damage (accounting for the defender's cover level).
+/// 2. Up to one [`PlayerActionChoice::MoveToCover`] per reachable cover level that
+///    is better than the actor's current cover, closest tile chosen for each level.
+/// 3. [`PlayerActionChoice::Pass`] (always present as the last entry).
+pub fn available_player_actions(world: &mut World, actor: Entity) -> Vec<PlayerActionChoice> {
+    let mut choices = Vec::new();
+
+    let ap = match world.get::<ActionPoints>(actor) {
+        Some(ap) => ap.current,
+        None => return choices,
+    };
+    let actor_pos = match world.get::<Position>(actor).copied() {
+        Some(p) => p,
+        None => return choices,
+    };
+    let actor_attack = world.get::<Stats>(actor).map(|s| s.attack).unwrap_or(0);
+
+    // ── Attack options ─────────────────────────────────────────────────────────
+    if ap >= ATTACK_AP_COST {
+        // Collect target data before borrowing resources.
+        let mut q = world.query::<(Entity, &Side, &Health, &Stats, &Position)>();
+        let targets: Vec<(Entity, i32, i32, i32)> = q
+            .iter(world)
+            .filter(|(_, s, h, _, _)| **s == Side::Enemy && h.is_alive())
+            .map(|(e, _, _, stats, pos)| (e, stats.defense, pos.x, pos.y))
+            .collect();
+
+        for (target_entity, defense, tx, ty) in targets {
+            let dir = Direction::from_attack((actor_pos.x, actor_pos.y), (tx, ty));
+            let cover = world
+                .get_resource::<LevelMap>()
+                .map(|m| m.get_cover(tx, ty, dir))
+                .unwrap_or(CoverLevel::None);
+            let hit_chance = calc_hit_chance(cover);
+            let damage = calc_damage(actor_attack, defense);
+            choices.push(PlayerActionChoice::Attack { target: target_entity, hit_chance, damage, cover });
+        }
+    }
+
+    // ── Cover move options ─────────────────────────────────────────────────────
+    let (cols, rows) = world
+        .get_resource::<LevelMap>()
+        .map(|m| (m.cols as i32, m.rows as i32))
+        .unwrap_or((0, 0));
+
+    if cols > 0 && rows > 0 {
+        let mut q2 = world.query::<(&Side, &Health, &Position)>();
+        let enemy_positions: Vec<(i32, i32)> = q2
+            .iter(world)
+            .filter(|(s, h, _)| **s == Side::Enemy && h.is_alive())
+            .map(|(_, _, pos)| (pos.x, pos.y))
+            .collect();
+
+        if let Some(&(ex, ey)) = enemy_positions
+            .iter()
+            .min_by_key(|(ex, ey)| (ex - actor_pos.x).abs() + (ey - actor_pos.y).abs())
+        {
+            let attack_dir = Direction::from_attack((ex, ey), (actor_pos.x, actor_pos.y));
+            let current_cover = world
+                .get_resource::<LevelMap>()
+                .map(|m| m.get_cover(actor_pos.x, actor_pos.y, attack_dir))
+                .unwrap_or(CoverLevel::None);
+
+            // Collect candidate cover tiles within AP budget.
+            let mut candidates: Vec<(CoverLevel, i32, i32, i32)> = Vec::new();
+            if let Some(map) = world.get_resource::<LevelMap>() {
+                for dy in -ap..=ap {
+                    for dx in -ap..=ap {
+                        let dist = dx.abs() + dy.abs();
+                        let cost = dist * MOVE_AP_COST;
+                        if dist == 0 || cost > ap {
+                            continue;
+                        }
+                        let tx = actor_pos.x + dx;
+                        let ty = actor_pos.y + dy;
+                        if tx < 0 || ty < 0 || tx >= cols || ty >= rows {
+                            continue;
+                        }
+                        if !map.is_passable(tx, ty) {
+                            continue;
+                        }
+                        let tile_cover = map.get_cover(tx, ty, attack_dir);
+                        if tile_cover > current_cover {
+                            candidates.push((tile_cover, dist, tx, ty));
+                        }
+                    }
+                }
+            }
+
+            // Best cover first, then closest. Emit one entry per cover level.
+            candidates.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
+            let mut seen: HashSet<u8> = HashSet::new();
+            for (tile_cover, dist, tx, ty) in candidates {
+                if seen.insert(tile_cover as u8) {
+                    choices.push(PlayerActionChoice::MoveToCover {
+                        destination: Position::new(tx, ty, actor_pos.z),
+                        cover: tile_cover,
+                        ap_cost: dist * MOVE_AP_COST,
+                    });
+                }
+            }
+        }
+    }
+
+    choices.push(PlayerActionChoice::Pass);
+    choices
+}

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -6,6 +6,7 @@ use crate::{
     action_points::ActionPoints,
     combat::{calc_damage, calc_hit_chance},
     health::Health,
+    player_input::{available_player_actions, PlayerActionChoice},
     position::Position,
     side::Side,
     stats::Stats,
@@ -40,18 +41,106 @@ pub struct TurnEvent {
     pub outcome: Option<BattleOutcome>,
 }
 
+/// Result of executing one player action via [`BattleStep::step_player_action`].
+#[derive(Debug)]
+pub struct PlayerTurnStep {
+    /// The entity that acted.
+    pub actor: Entity,
+    /// The logged action (None if the choice was Pass or otherwise invalid).
+    pub action: Option<TurnAction>,
+    /// Whether the actor's turn has now ended (AP exhausted or Pass chosen).
+    /// When `true`, the next call to `player_choices` returns choices for the
+    /// following player actor, or an empty vec if all players have acted.
+    pub turn_ended: bool,
+    /// Set when the battle ends as a result of this action.
+    pub outcome: Option<BattleOutcome>,
+}
+
 /// Incremental battle driver: call `step()` once per key-press.
 /// All combatants must carry `Side`, `Health`, `Stats`, and `ActionPoints`.
 pub struct BattleStep {
     pub round: u32,
     pub side: Side,
     actor_queue: VecDeque<Entity>,
+    /// Whether the current player actor's AP has been refreshed this turn.
+    player_actor_ready: bool,
 }
 
 impl BattleStep {
     pub fn new(world: &mut World) -> Self {
         let queue = VecDeque::from(living_side(world, Side::Player));
-        Self { round: 1, side: Side::Player, actor_queue: queue }
+        Self { round: 1, side: Side::Player, actor_queue: queue, player_actor_ready: false }
+    }
+
+    /// Returns available actions for the next queued player actor.
+    ///
+    /// Refreshes the actor's AP automatically the first time this is called for
+    /// a given actor. Returns an empty vec when:
+    /// * it is not the player's turn (`self.side == Side::Enemy`),
+    /// * all player actors have already acted (queue empty), or
+    /// * the battle is already over.
+    pub fn player_choices(&mut self, world: &mut World) -> Vec<PlayerActionChoice> {
+        if self.side != Side::Player || check_outcome(world).is_some() {
+            return vec![];
+        }
+        let actor = match self.actor_queue.front().copied() {
+            Some(e) => e,
+            None => return vec![],
+        };
+        if !self.player_actor_ready {
+            refresh_actor(world, actor);
+            self.player_actor_ready = true;
+        }
+        available_player_actions(world, actor)
+    }
+
+    /// Execute one player-chosen action for the current queued player actor.
+    ///
+    /// When `result.turn_ended` is `true`, the actor has been removed from the
+    /// queue. Call `player_choices` again to get options for the next player
+    /// actor. Once the player queue is exhausted, `self.side` switches to
+    /// `Side::Enemy` automatically; call `step()` for each enemy actor then.
+    pub fn step_player_action(
+        &mut self,
+        world: &mut World,
+        choice: &PlayerActionChoice,
+    ) -> PlayerTurnStep {
+        let actor = match self.actor_queue.front().copied() {
+            Some(e) => e,
+            None => {
+                return PlayerTurnStep {
+                    actor: Entity::PLACEHOLDER,
+                    action: None,
+                    turn_ended: true,
+                    outcome: check_outcome(world),
+                };
+            }
+        };
+
+        if !self.player_actor_ready {
+            refresh_actor(world, actor);
+            self.player_actor_ready = true;
+        }
+
+        let action = choice.to_action();
+        let logged = apply_action(world, actor, &action);
+
+        let is_pass = matches!(choice, PlayerActionChoice::Pass);
+        let ap_remaining = world.get::<ActionPoints>(actor).map(|ap| ap.current).unwrap_or(0);
+        let turn_ended = is_pass || ap_remaining == 0;
+
+        if turn_ended {
+            self.actor_queue.pop_front();
+            self.player_actor_ready = false;
+
+            // When all players have acted, switch to the enemy side.
+            if self.actor_queue.is_empty() {
+                self.side = Side::Enemy;
+                self.actor_queue = VecDeque::from(living_side(world, Side::Enemy));
+            }
+        }
+
+        PlayerTurnStep { actor, action: logged, turn_ended, outcome: check_outcome(world) }
     }
 
     /// The next entity waiting to act this side, if any.

--- a/tests/player_input_tests.rs
+++ b/tests/player_input_tests.rs
@@ -1,0 +1,379 @@
+use bevy::prelude::*;
+use carbonthrone::{
+    action_points::ActionPoints,
+    combat::BASE_HIT_CHANCE,
+    health::Health,
+    player_input::{available_player_actions, PlayerActionChoice},
+    position::Position,
+    side::Side,
+    simulation::{BattleStep, BattleOutcome},
+    stats::Stats,
+    terrain::{Biome, CoverLevel, LevelMap, Tile},
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+fn spawn_player(world: &mut World, pos: (i32, i32), attack: i32, defense: i32) -> Entity {
+    world
+        .spawn((
+            Side::Player,
+            Health::new(100),
+            Stats { max_hp: 100, attack, defense, speed: 10 },
+            ActionPoints::new(4),
+            Position::new(pos.0, pos.1, 0),
+        ))
+        .id()
+}
+
+fn spawn_enemy(world: &mut World, pos: (i32, i32), defense: i32) -> Entity {
+    world
+        .spawn((
+            Side::Enemy,
+            Health::new(50),
+            Stats { max_hp: 50, attack: 5, defense, speed: 5 },
+            ActionPoints::new(4),
+            Position::new(pos.0, pos.1, 0),
+        ))
+        .id()
+}
+
+// ── available_player_actions ───────────────────────────────────────────────────
+
+#[test]
+fn always_ends_with_pass() {
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (0, 0), 10, 5);
+    let choices = available_player_actions(&mut world, actor);
+    assert!(matches!(choices.last(), Some(PlayerActionChoice::Pass)));
+}
+
+#[test]
+fn attack_choice_listed_for_each_living_enemy() {
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (0, 0), 10, 5);
+    spawn_enemy(&mut world, (5, 0), 4);
+    spawn_enemy(&mut world, (0, 5), 2);
+
+    let choices = available_player_actions(&mut world, actor);
+    let attacks: Vec<_> = choices
+        .iter()
+        .filter(|c| matches!(c, PlayerActionChoice::Attack { .. }))
+        .collect();
+    assert_eq!(attacks.len(), 2, "one attack choice per living enemy");
+}
+
+#[test]
+fn attack_choice_has_correct_hit_chance_no_cover() {
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (0, 0), 10, 5);
+    spawn_enemy(&mut world, (5, 0), 4);
+
+    let choices = available_player_actions(&mut world, actor);
+    for choice in &choices {
+        if let PlayerActionChoice::Attack { hit_chance, cover, .. } = choice {
+            assert_eq!(*cover, CoverLevel::None);
+            assert!((hit_chance - BASE_HIT_CHANCE).abs() < 0.001,
+                "no-cover hit chance should be {BASE_HIT_CHANCE}");
+        }
+    }
+}
+
+#[test]
+fn attack_choice_reflects_partial_cover() {
+    // Target at (5,5); obstacle diagonally from North-West → partial cover from West.
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (0, 5), 10, 5); // attacker approaches from West
+    spawn_enemy(&mut world, (5, 5), 4);
+
+    let mut map = LevelMap::new(10, 10, Biome::VoidStation);
+    // Obstacle at (4,4) — diagonal neighbor of (5,5) from the west direction.
+    map.set(4, 4, Tile::Obstacle);
+    map.recompute_cover();
+    world.insert_resource(map);
+
+    let choices = available_player_actions(&mut world, actor);
+    let attack_opt = choices.iter().find_map(|c| {
+        if let PlayerActionChoice::Attack { hit_chance, cover, .. } = c {
+            Some((*hit_chance, *cover))
+        } else {
+            None
+        }
+    });
+    let (hit_chance, cover) = attack_opt.expect("expected an attack choice");
+    assert_eq!(cover, CoverLevel::Partial);
+    assert!((hit_chance - 0.65).abs() < 0.001, "partial cover → 65% hit chance");
+}
+
+#[test]
+fn attack_choice_reflects_full_cover() {
+    // Target at (5,5); obstacle directly north at (5,4) — Full cover from North.
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (5, 0), 10, 5); // approaches from North
+    spawn_enemy(&mut world, (5, 5), 4);
+
+    let mut map = LevelMap::new(10, 10, Biome::VoidStation);
+    map.set(5, 4, Tile::Obstacle);
+    map.recompute_cover();
+    world.insert_resource(map);
+
+    let choices = available_player_actions(&mut world, actor);
+    let (hit_chance, cover) = choices.iter().find_map(|c| {
+        if let PlayerActionChoice::Attack { hit_chance, cover, .. } = c { Some((*hit_chance, *cover)) } else { None }
+    }).expect("expected an attack choice");
+
+    assert_eq!(cover, CoverLevel::Full);
+    assert!((hit_chance - 0.35).abs() < 0.001, "full cover → 35% hit chance");
+}
+
+#[test]
+fn attack_choice_reflects_correct_damage() {
+    // calc_damage(attack=10, defense=4) = 10 - 4/2 = 8
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (0, 0), 10, 5);
+    spawn_enemy(&mut world, (5, 0), 4);
+
+    let choices = available_player_actions(&mut world, actor);
+    let damage = choices.iter().find_map(|c| {
+        if let PlayerActionChoice::Attack { damage, .. } = c { Some(*damage) } else { None }
+    }).expect("expected attack choice");
+    assert_eq!(damage, 8);
+}
+
+#[test]
+fn no_attack_choices_when_ap_too_low() {
+    let mut world = World::new();
+    // Actor with only 1 AP — ATTACK_AP_COST is 2, so no attacks should appear.
+    let actor = world
+        .spawn((
+            Side::Player,
+            Health::new(100),
+            Stats { max_hp: 100, attack: 10, defense: 5, speed: 10 },
+            ActionPoints::new(1),
+            Position::new(0, 0, 0),
+        ))
+        .id();
+    spawn_enemy(&mut world, (5, 0), 4);
+
+    let choices = available_player_actions(&mut world, actor);
+    assert!(!choices.iter().any(|c| matches!(c, PlayerActionChoice::Attack { .. })));
+}
+
+#[test]
+fn move_to_cover_option_listed_when_cover_available() {
+    // Actor at (0,5); obstacle at (3,4) provides full cover from East (enemy at (9,5)).
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (0, 5), 10, 5);
+    spawn_enemy(&mut world, (9, 5), 4);
+
+    let mut map = LevelMap::new(10, 10, Biome::VoidStation);
+    map.set(3, 4, Tile::Obstacle); // full cover at (3,5) from East
+    map.recompute_cover();
+    world.insert_resource(map);
+
+    let choices = available_player_actions(&mut world, actor);
+    let cover_moves: Vec<_> = choices
+        .iter()
+        .filter(|c| matches!(c, PlayerActionChoice::MoveToCover { .. }))
+        .collect();
+    assert!(!cover_moves.is_empty(), "expected at least one MoveToCover option");
+}
+
+#[test]
+fn no_move_to_cover_when_already_at_full_cover() {
+    // Put obstacle directly East of actor so they already have full cover.
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (2, 5), 10, 5);
+    spawn_enemy(&mut world, (9, 5), 4); // enemy to the East
+
+    let mut map = LevelMap::new(10, 10, Biome::VoidStation);
+    map.set(3, 5, Tile::Obstacle); // directly East of actor → full cover from East
+    map.recompute_cover();
+    world.insert_resource(map);
+
+    let choices = available_player_actions(&mut world, actor);
+    assert!(
+        !choices.iter().any(|c| matches!(c, PlayerActionChoice::MoveToCover { .. })),
+        "already at full cover — no MoveToCover should be offered",
+    );
+}
+
+#[test]
+fn move_to_cover_ap_cost_is_correct() {
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (0, 5), 10, 5);
+    spawn_enemy(&mut world, (9, 5), 4);
+
+    let mut map = LevelMap::new(10, 10, Biome::VoidStation);
+    map.set(3, 4, Tile::Obstacle); // cover for (3,5)
+    map.recompute_cover();
+    world.insert_resource(map);
+
+    let choices = available_player_actions(&mut world, actor);
+    for c in &choices {
+        if let PlayerActionChoice::MoveToCover { destination, ap_cost, .. } = c {
+            let dist = (destination.x - 0).abs() + (destination.y - 5).abs();
+            assert_eq!(*ap_cost, dist, "ap_cost should equal Manhattan distance (MOVE_AP_COST=1)");
+        }
+    }
+}
+
+#[test]
+fn display_strings_are_non_empty() {
+    let mut world = World::new();
+    let actor = spawn_player(&mut world, (0, 0), 10, 5);
+    spawn_enemy(&mut world, (5, 0), 4);
+
+    let choices = available_player_actions(&mut world, actor);
+    for choice in &choices {
+        assert!(!choice.display().is_empty());
+    }
+}
+
+// ── BattleStep player control ─────────────────────────────────────────────────
+
+#[test]
+fn player_choices_returns_options_on_player_turn() {
+    let mut world = World::new();
+    world.spawn((
+        Side::Player,
+        Health::new(100),
+        Stats { max_hp: 100, attack: 10, defense: 5, speed: 10 },
+        ActionPoints::new(4),
+        Position::new(0, 0, 0),
+    ));
+    world.spawn((
+        Side::Enemy,
+        Health::new(50),
+        Stats { max_hp: 50, attack: 5, defense: 4, speed: 5 },
+        ActionPoints::new(4),
+        Position::new(5, 0, 0),
+    ));
+
+    let mut bs = BattleStep::new(&mut world);
+    let choices = bs.player_choices(&mut world);
+    assert!(!choices.is_empty());
+    assert!(choices.iter().any(|c| matches!(c, PlayerActionChoice::Attack { .. })));
+    assert!(choices.iter().any(|c| matches!(c, PlayerActionChoice::Pass)));
+}
+
+#[test]
+fn player_choices_empty_on_enemy_turn() {
+    let mut world = World::new();
+    world.spawn((
+        Side::Player,
+        Health::new(100),
+        Stats { max_hp: 100, attack: 10, defense: 5, speed: 10 },
+        ActionPoints::new(4),
+        Position::new(0, 0, 0),
+    ));
+    world.spawn((
+        Side::Enemy,
+        Health::new(50),
+        Stats { max_hp: 50, attack: 5, defense: 4, speed: 5 },
+        ActionPoints::new(4),
+        Position::new(5, 0, 0),
+    ));
+
+    let mut bs = BattleStep::new(&mut world);
+    // Manually advance to enemy side.
+    bs.step(&mut world); // processes the player turn via AI
+    // Now it should be the enemy side.
+    if bs.side == carbonthrone::side::Side::Enemy {
+        let choices = bs.player_choices(&mut world);
+        assert!(choices.is_empty());
+    }
+}
+
+#[test]
+fn step_player_action_pass_ends_turn() {
+    let mut world = World::new();
+    let player = world
+        .spawn((
+            Side::Player,
+            Health::new(100),
+            Stats { max_hp: 100, attack: 10, defense: 5, speed: 10 },
+            ActionPoints::new(4),
+            Position::new(0, 0, 0),
+        ))
+        .id();
+    world.spawn((
+        Side::Enemy,
+        Health::new(50),
+        Stats { max_hp: 50, attack: 5, defense: 4, speed: 5 },
+        ActionPoints::new(4),
+        Position::new(5, 0, 0),
+    ));
+
+    let mut bs = BattleStep::new(&mut world);
+    bs.player_choices(&mut world); // initialise (refresh AP)
+
+    let result = bs.step_player_action(&mut world, &PlayerActionChoice::Pass);
+    assert_eq!(result.actor, player);
+    assert!(result.turn_ended);
+    assert!(result.action.is_none());
+}
+
+#[test]
+fn step_player_action_attack_deals_damage() {
+    let mut world = World::new();
+    world.spawn((
+        Side::Player,
+        Health::new(100),
+        Stats { max_hp: 100, attack: 20, defense: 5, speed: 10 },
+        ActionPoints::new(4),
+        Position::new(0, 0, 0),
+    ));
+    let enemy = world
+        .spawn((
+            Side::Enemy,
+            Health::new(50),
+            Stats { max_hp: 50, attack: 5, defense: 0, speed: 5 },
+            ActionPoints::new(4),
+            Position::new(5, 0, 0),
+        ))
+        .id();
+
+    let mut bs = BattleStep::new(&mut world);
+    let choices = bs.player_choices(&mut world);
+
+    // Pick the attack choice targeting the enemy.
+    let attack_choice = choices
+        .iter()
+        .find(|c| matches!(c, PlayerActionChoice::Attack { .. }))
+        .expect("expected an attack choice");
+
+    bs.step_player_action(&mut world, attack_choice);
+
+    // Enemy should have taken damage (no BattleRng → always hits).
+    let hp = world.get::<Health>(enemy).unwrap().current;
+    assert!(hp < 50, "enemy should have taken damage");
+}
+
+#[test]
+fn step_player_action_outcome_set_on_victory() {
+    let mut world = World::new();
+    world.spawn((
+        Side::Player,
+        Health::new(100),
+        Stats { max_hp: 100, attack: 100, defense: 5, speed: 10 },
+        ActionPoints::new(4),
+        Position::new(0, 0, 0),
+    ));
+    world.spawn((
+        Side::Enemy,
+        Health::new(1),
+        Stats { max_hp: 1, attack: 5, defense: 0, speed: 5 },
+        ActionPoints::new(4),
+        Position::new(5, 0, 0),
+    ));
+
+    let mut bs = BattleStep::new(&mut world);
+    let choices = bs.player_choices(&mut world);
+    let attack = choices
+        .iter()
+        .find(|c| matches!(c, PlayerActionChoice::Attack { .. }))
+        .unwrap();
+
+    let result = bs.step_player_action(&mut world, attack);
+    assert_eq!(result.outcome, Some(BattleOutcome::PlayerVictory));
+}


### PR DESCRIPTION
Implements #010: player-controlled combat turns with multiple-choice menus.

- New `player_input` module with `PlayerActionChoice` enum and `available_player_actions()`
- Attack options show hit probability (%90%/65%/35%) and expected damage based on defender's cover
- MoveToCover options list reachable cover tiles better than current position
- `BattleStep` gains `player_choices()` and `step_player_action()` for incremental player-driven turns
- 14 integration tests

Closes #10

Generated with [Claude Code](https://claude.ai/code)