### PR TITLE
feat: update abilities and combat system

### DIFF
--- a/src/ability.rs
+++ b/src/ability.rs
@@ -2,6 +2,19 @@ use bevy::prelude::Component;
 
 use crate::character::CharacterKind;
 
+/// Classifies how an ability is used in relation to the target's position.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AbilityKind {
+    /// Only usable when the target is within Chebyshev distance 1 (any adjacent tile,
+    /// including diagonals). Each character has at most one melee attack.
+    Melee,
+    /// Usable at any range. Each character has at most one ranged weapon
+    /// (abilities that deal damage). Disruption/utility ranged abilities are uncapped.
+    Ranged,
+    /// Self-targeted or battlefield-wide; no positional restriction.
+    Utility,
+}
+
 /// The mechanical effect of using an ability in combat.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AbilityEffect {
@@ -29,6 +42,8 @@ pub struct Ability {
     /// Action-point cost to activate.
     pub ap_cost: i32,
     pub effect: AbilityEffect,
+    /// Positional constraint: Melee requires adjacency; Ranged works at any distance.
+    pub kind: AbilityKind,
 }
 
 /// Bevy component that records which character this entity is for ability queries.
@@ -52,11 +67,33 @@ impl CharacterAbilities {
 /// Returns all abilities defined for `character`.
 pub fn character_abilities(character: &CharacterKind) -> Vec<Ability> {
     match character {
+        // Player characters
         CharacterKind::Researcher => researcher_abilities(),
         CharacterKind::Orin => orin_abilities(),
         CharacterKind::Doss => doss_abilities(),
         CharacterKind::Kaleo => kaleo_abilities(),
-        _ => panic!("character_abilities called on NPC kind {:?}", character),
+        // The Constancy
+        CharacterKind::Zealot => zealot_abilities(),
+        CharacterKind::Preacher => preacher_abilities(),
+        CharacterKind::Purifier => purifier_abilities(),
+        CharacterKind::Archon => archon_abilities(),
+        // Drifters
+        CharacterKind::Scavenger => scavenger_abilities(),
+        CharacterKind::VoidRaider => void_raider_abilities(),
+        CharacterKind::DrifterBoss => drifter_boss_abilities(),
+        // Automata
+        CharacterKind::MaintenanceDrone => maintenance_drone_abilities(),
+        CharacterKind::SecurityUnit => security_unit_abilities(),
+        CharacterKind::CombatFrame => combat_frame_abilities(),
+        // Abyssal Fauna
+        CharacterKind::MoonCrawler => moon_crawler_abilities(),
+        CharacterKind::VoidSpitter => void_spitter_abilities(),
+        CharacterKind::AbyssalBrute => abyssal_brute_abilities(),
+        // Station Personnel
+        CharacterKind::SalvageOperative => salvage_operative_abilities(),
+        CharacterKind::GunForHire => gun_for_hire_abilities(),
+        CharacterKind::StationGuard => station_guard_abilities(),
+        CharacterKind::ShockTrooper => shock_trooper_abilities(),
     }
 }
 
@@ -68,23 +105,25 @@ pub fn available_abilities(character: &CharacterKind, level: u32) -> Vec<Ability
         .collect()
 }
 
-// ── Per-character ability tables ──────────────────────────────────────────────
+// ── Player character ability tables ───────────────────────────────────────────
 
 fn researcher_abilities() -> Vec<Ability> {
     vec![
         Ability {
             name: "Temporal Bolt",
-            description: "A focused burst of temporal energy that deals significant bonus damage.",
+            description: "A focused burst of temporal energy fired at range, dealing significant bonus damage.",
             level_required: 1,
             ap_cost: 3,
             effect: AbilityEffect::BonusDamage { bonus: 10 },
+            kind: AbilityKind::Ranged,
         },
         Ability {
             name: "Stasis",
-            description: "Lock an enemy in a temporal freeze, draining their action economy.",
+            description: "Lock an enemy in a temporal freeze at range, draining their action economy.",
             level_required: 6,
             ap_cost: 2,
             effect: AbilityEffect::DrainAP { amount: 3 },
+            kind: AbilityKind::Ranged,
         },
         Ability {
             name: "Rewind",
@@ -92,6 +131,7 @@ fn researcher_abilities() -> Vec<Ability> {
             level_required: 12,
             ap_cost: 3,
             effect: AbilityEffect::Heal { amount: 35 },
+            kind: AbilityKind::Utility,
         },
     ]
 }
@@ -104,13 +144,15 @@ fn doss_abilities() -> Vec<Ability> {
             level_required: 1,
             ap_cost: 3,
             effect: AbilityEffect::BonusDamage { bonus: 8 },
+            kind: AbilityKind::Melee,
         },
         Ability {
             name: "Shield Bash",
-            description: "Strike the enemy with your shield, disrupting their next action.",
+            description: "Strike the enemy with your shield in close quarters, disrupting their next action.",
             level_required: 5,
             ap_cost: 2,
             effect: AbilityEffect::DrainAP { amount: 1 },
+            kind: AbilityKind::Melee,
         },
         Ability {
             name: "Adrenaline Rush",
@@ -118,6 +160,7 @@ fn doss_abilities() -> Vec<Ability> {
             level_required: 12,
             ap_cost: 0,
             effect: AbilityEffect::GrantAP { amount: 2 },
+            kind: AbilityKind::Utility,
         },
     ]
 }
@@ -130,6 +173,7 @@ fn orin_abilities() -> Vec<Ability> {
             level_required: 1,
             ap_cost: 2,
             effect: AbilityEffect::Heal { amount: 20 },
+            kind: AbilityKind::Utility,
         },
         Ability {
             name: "Greater Heal",
@@ -137,6 +181,7 @@ fn orin_abilities() -> Vec<Ability> {
             level_required: 7,
             ap_cost: 3,
             effect: AbilityEffect::Heal { amount: 45 },
+            kind: AbilityKind::Utility,
         },
         Ability {
             name: "Divine Restoration",
@@ -144,6 +189,7 @@ fn orin_abilities() -> Vec<Ability> {
             level_required: 14,
             ap_cost: 4,
             effect: AbilityEffect::Heal { amount: 80 },
+            kind: AbilityKind::Utility,
         },
     ]
 }
@@ -152,27 +198,289 @@ fn kaleo_abilities() -> Vec<Ability> {
     vec![
         Ability {
             name: "Aimed Shot",
-            description: "A carefully lined-up shot that deals bonus damage.",
+            description: "A carefully lined-up ranged shot that deals bonus damage.",
             level_required: 1,
             ap_cost: 2,
             effect: AbilityEffect::BonusDamage { bonus: 5 },
+            kind: AbilityKind::Ranged,
         },
         Ability {
             name: "System Hack",
-            description: "Interface with enemy systems to disrupt their action economy.",
+            description: "Interface with enemy systems at range to disrupt their action economy.",
             level_required: 5,
             ap_cost: 2,
             effect: AbilityEffect::DrainAP { amount: 2 },
+            kind: AbilityKind::Ranged,
         },
         Ability {
             name: "Precision Barrage",
-            description: "A sustained volley of precise fire that shreds armor and deals heavy damage.",
+            description: "A sustained close-range volley of precise fire that shreds armor and deals heavy damage.",
             level_required: 10,
             ap_cost: 4,
             effect: AbilityEffect::ArmorPiercingStrike {
                 pierce_fraction: 0.5,
                 bonus: 10,
             },
+            kind: AbilityKind::Melee,
+        },
+    ]
+}
+
+// ── NPC ability tables ─────────────────────────────────────────────────────────
+
+// The Constancy
+
+fn zealot_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Zealot Strike",
+        description: "A fanatical melee charge driven by absolute conviction.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 5 },
+        kind: AbilityKind::Melee,
+    }]
+}
+
+fn preacher_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Dampen Temporal Field",
+        description: "Emit a suppression pulse that drains a target's temporal action economy.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::DrainAP { amount: 1 },
+        kind: AbilityKind::Ranged,
+    }]
+}
+
+fn purifier_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Purifying Round",
+        description: "An anti-temporal round fired from range that deals bonus damage.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 8 },
+        kind: AbilityKind::Ranged,
+    }]
+}
+
+fn archon_abilities() -> Vec<Ability> {
+    vec![
+        Ability {
+            name: "Armored Crush",
+            description: "A devastating melee blow from a heavily armored frame that pierces defenses.",
+            level_required: 1,
+            ap_cost: 3,
+            effect: AbilityEffect::ArmorPiercing {
+                pierce_fraction: 0.3,
+            },
+            kind: AbilityKind::Melee,
+        },
+        Ability {
+            name: "Temporal Suppression",
+            description: "Activate the zone-wide Flux dampener, draining a target's action points.",
+            level_required: 1,
+            ap_cost: 2,
+            effect: AbilityEffect::DrainAP { amount: 2 },
+            kind: AbilityKind::Ranged,
+        },
+    ]
+}
+
+// Drifters
+
+fn scavenger_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Quick Slash",
+        description: "A fast, opportunistic melee strike from a glass-cannon scavenger.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 3 },
+        kind: AbilityKind::Melee,
+    }]
+}
+
+fn void_raider_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Suppressive Fire",
+        description: "A burst of gunfire from range that keeps targets pinned.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 5 },
+        kind: AbilityKind::Ranged,
+    }]
+}
+
+fn drifter_boss_abilities() -> Vec<Ability> {
+    vec![
+        Ability {
+            name: "Heavy Blow",
+            description: "A crushing melee strike from the pack leader.",
+            level_required: 1,
+            ap_cost: 3,
+            effect: AbilityEffect::BonusDamage { bonus: 10 },
+            kind: AbilityKind::Melee,
+        },
+        Ability {
+            name: "Rally",
+            description: "Bark orders to push through the fight, gaining a burst of extra action.",
+            level_required: 1,
+            ap_cost: 0,
+            effect: AbilityEffect::GrantAP { amount: 1 },
+            kind: AbilityKind::Utility,
+        },
+    ]
+}
+
+// Automata
+
+fn maintenance_drone_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Maintenance Strike",
+        description: "An erratic melee blow from a corrupted maintenance unit.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 2 },
+        kind: AbilityKind::Melee,
+    }]
+}
+
+fn security_unit_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Security Fire",
+        description: "A controlled ranged burst from a corrupted security patrol unit.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 6 },
+        kind: AbilityKind::Ranged,
+    }]
+}
+
+fn combat_frame_abilities() -> Vec<Ability> {
+    vec![
+        Ability {
+            name: "Mech Strike",
+            description: "A punishing melee blow from a military-grade combat frame that shreds armor.",
+            level_required: 1,
+            ap_cost: 3,
+            effect: AbilityEffect::ArmorPiercingStrike {
+                pierce_fraction: 0.4,
+                bonus: 8,
+            },
+            kind: AbilityKind::Melee,
+        },
+        Ability {
+            name: "Heavy Cannon",
+            description: "A devastating ranged salvo from the combat frame's main armament.",
+            level_required: 1,
+            ap_cost: 3,
+            effect: AbilityEffect::BonusDamage { bonus: 15 },
+            kind: AbilityKind::Ranged,
+        },
+    ]
+}
+
+// Abyssal Fauna
+
+fn moon_crawler_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Feral Pounce",
+        description: "A lightning-fast melee lunge from the fastest creature on the moon.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 4 },
+        kind: AbilityKind::Melee,
+    }]
+}
+
+fn void_spitter_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Bio Spit",
+        description: "A ranged biological projectile with magic-adjacent corrosive damage.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 7 },
+        kind: AbilityKind::Ranged,
+    }]
+}
+
+fn abyssal_brute_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Crushing Blow",
+        description: "A slow but devastating melee strike from the apex predator that pierces armor.",
+        level_required: 1,
+        ap_cost: 3,
+        effect: AbilityEffect::ArmorPiercing {
+            pierce_fraction: 0.5,
+        },
+        kind: AbilityKind::Melee,
+    }]
+}
+
+// Station Personnel
+
+fn salvage_operative_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Quick Shot",
+        description: "A hasty ranged shot from a lightly armed mercenary.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 3 },
+        kind: AbilityKind::Ranged,
+    }]
+}
+
+fn gun_for_hire_abilities() -> Vec<Ability> {
+    vec![Ability {
+        name: "Contract Shot",
+        description: "A professional ranged shot from an armed contractor.",
+        level_required: 1,
+        ap_cost: 2,
+        effect: AbilityEffect::BonusDamage { bonus: 7 },
+        kind: AbilityKind::Ranged,
+    }]
+}
+
+fn station_guard_abilities() -> Vec<Ability> {
+    vec![
+        Ability {
+            name: "Security Baton",
+            description: "A close-quarters melee strike with a security enforcement baton.",
+            level_required: 1,
+            ap_cost: 2,
+            effect: AbilityEffect::BonusDamage { bonus: 4 },
+            kind: AbilityKind::Melee,
+        },
+        Ability {
+            name: "Warning Shot",
+            description: "A ranged shot from station security — effective at any range.",
+            level_required: 1,
+            ap_cost: 2,
+            effect: AbilityEffect::BonusDamage { bonus: 5 },
+            kind: AbilityKind::Ranged,
+        },
+    ]
+}
+
+fn shock_trooper_abilities() -> Vec<Ability> {
+    vec![
+        Ability {
+            name: "Shock Assault",
+            description: "A brutal close-quarters assault that pierces armor and deals heavy damage.",
+            level_required: 1,
+            ap_cost: 3,
+            effect: AbilityEffect::ArmorPiercingStrike {
+                pierce_fraction: 0.2,
+                bonus: 5,
+            },
+            kind: AbilityKind::Melee,
+        },
+        Ability {
+            name: "Assault Fire",
+            description: "A disciplined burst of automatic fire from a military enforcer.",
+            level_required: 1,
+            ap_cost: 2,
+            effect: AbilityEffect::BonusDamage { bonus: 10 },
+            kind: AbilityKind::Ranged,
         },
     ]
 }

--- a/src/combat.rs
+++ b/src/combat.rs
@@ -4,6 +4,7 @@ use bevy::prelude::*;
 use rand::Rng;
 
 use crate::{
+    ability::{AbilityEffect, AbilityKind, character_abilities},
     action_points::ActionPoints,
     character::{Aggression, Character},
     health::Health,
@@ -11,7 +12,7 @@ use crate::{
     position::Position,
     stats::Stats,
     terrain::{CoverLevel, Direction, LevelMap},
-    turn::{ATTACK_AP_COST, Action, apply_action},
+    turn::{Action, apply_action},
 };
 
 pub use crate::turn::TurnAction;
@@ -383,36 +384,201 @@ fn all_enemies_defeated(world: &mut World) -> bool {
 
 // ── Smart AI ─────────────────────────────────────────────────────────────────
 
-/// AI entry point: seek cover first, then attack the best target.
+/// Returns the minimum AP cost of any offensive (Melee or Ranged damage) ability
+/// for the given actor. Falls back to 2 if no character or no abilities found.
+fn min_offensive_ap_cost(world: &mut World, actor: Entity) -> i32 {
+    let kind = match world.get::<Character>(actor) {
+        Some(c) => c.kind.clone(),
+        None => return 2,
+    };
+    character_abilities(&kind)
+        .iter()
+        .filter(|a| matches!(a.kind, AbilityKind::Melee | AbilityKind::Ranged))
+        .filter(|a| is_damage_ability(&a.effect))
+        .map(|a| a.ap_cost)
+        .min()
+        .unwrap_or(2)
+}
+
+/// Returns `true` if the ability effect deals direct damage.
+fn is_damage_ability(effect: &AbilityEffect) -> bool {
+    matches!(
+        effect,
+        AbilityEffect::BonusDamage { .. }
+            | AbilityEffect::ArmorPiercing { .. }
+            | AbilityEffect::ArmorPiercingStrike { .. }
+    )
+}
+
+/// Returns `true` for abilities that can be directed at an enemy to impair them
+/// (damage dealing or AP disruption).
+fn is_offensive_ability(effect: &AbilityEffect) -> bool {
+    matches!(
+        effect,
+        AbilityEffect::BonusDamage { .. }
+            | AbilityEffect::ArmorPiercing { .. }
+            | AbilityEffect::ArmorPiercingStrike { .. }
+            | AbilityEffect::DrainAP { .. }
+    )
+}
+
+/// AI entry point: seek cover first, then choose an ability.
 fn choose_action(world: &mut World, actor: Entity, turn: Turn) -> Option<Action> {
     let ap = world.get::<ActionPoints>(actor)?.current;
     if ap == 0 {
         return Some(Action::Pass);
     }
 
+    let min_cost = min_offensive_ap_cost(world, actor);
+
     // Phase 1: move to cover if not already well-covered from nearest enemy.
-    if let Some(mv) = seek_cover_action(world, actor, turn, ap) {
+    if let Some(mv) = seek_cover_action(world, actor, turn, ap, min_cost) {
         return Some(mv);
     }
 
-    // Phase 2: attack the target most likely to take significant damage.
-    if ap >= ATTACK_AP_COST
-        && let Some(target) = best_attack_target(world, actor, turn)
-    {
-        return Some(Action::Attack { target });
+    // Phase 2: use an offensive ability.
+    if let Some(ability_action) = choose_offensive_ability_action(world, actor, turn, ap) {
+        return Some(ability_action);
     }
 
     Some(Action::Pass)
 }
 
+/// Chooses an offensive ability and target for the actor.
+///
+/// Prefers ranged abilities (usable from any distance), then melee (adjacent only).
+/// Returns `None` if no valid target/ability combination is available.
+fn choose_offensive_ability_action(
+    world: &mut World,
+    actor: Entity,
+    turn: Turn,
+    ap: i32,
+) -> Option<Action> {
+    let (kind, level) = {
+        let c = world.get::<Character>(actor)?;
+        (c.kind.clone(), c.level)
+    };
+    let actor_pos = world.get::<Position>(actor).copied()?;
+
+    let abilities = character_abilities(&kind);
+    let available: Vec<_> = abilities
+        .iter()
+        .filter(|a| a.level_required <= level && a.ap_cost <= ap && is_offensive_ability(&a.effect))
+        .collect();
+
+    // Collect target positions for adjacency checks.
+    let target_positions: Vec<(Entity, i32, i32)> = {
+        let mut q = world.query::<(Entity, &Character, &Health, &Position)>();
+        q.iter(world)
+            .filter(|(_, c, h, _)| match turn {
+                Turn::Player => {
+                    !c.kind.is_player() && c.aggression != Aggression::Friendly && h.is_alive()
+                }
+                Turn::Enemy => c.kind.is_player() && h.is_alive(),
+            })
+            .map(|(e, _, _, pos)| (e, pos.x, pos.y))
+            .collect()
+    };
+
+    // Try ranged offensive abilities first.
+    if let Some(ability) = available.iter().find(|a| a.kind == AbilityKind::Ranged) {
+        if let Some(target) = best_attack_target(world, actor, turn) {
+            return Some(Action::UseAbility {
+                ability: (*ability).clone(),
+                target: Some(target),
+            });
+        }
+    }
+
+    // Try melee offensive abilities if an adjacent target exists.
+    if let Some(ability) = available.iter().find(|a| a.kind == AbilityKind::Melee) {
+        if let Some(target) = best_adjacent_target(&target_positions, actor_pos) {
+            return Some(Action::UseAbility {
+                ability: (*ability).clone(),
+                target: Some(target),
+            });
+        }
+    }
+
+    None
+}
+
+/// Returns the entity that gives the highest expected damage (hit_chance × damage),
+/// preferring closer targets on ties.
+fn best_attack_target(world: &mut World, actor: Entity, turn: Turn) -> Option<Entity> {
+    let actor_pos = world.get::<Position>(actor).copied()?;
+    let actor_attack = world.get::<Stats>(actor).map(|s| s.attack).unwrap_or(0);
+
+    // Collect target data (drop query borrow before accessing resources).
+    let targets: Vec<(Entity, i32, i32, i32)> = match turn {
+        Turn::Player => {
+            let mut q = world.query::<(Entity, &Character, &Health, &Stats, &Position)>();
+            q.iter(world)
+                .filter(|(_, c, h, _, _)| {
+                    !c.kind.is_player() && c.aggression != Aggression::Friendly && h.is_alive()
+                })
+                .map(|(e, _, _, stats, pos)| (e, stats.defense, pos.x, pos.y))
+                .collect()
+        }
+        Turn::Enemy => {
+            let mut q = world.query::<(Entity, &Character, &Health, &Stats, &Position)>();
+            q.iter(world)
+                .filter(|(_, c, h, _, _)| c.kind.is_player() && h.is_alive())
+                .map(|(e, _, _, stats, pos)| (e, stats.defense, pos.x, pos.y))
+                .collect()
+        }
+    };
+
+    targets
+        .iter()
+        .map(|&(e, defense, tx, ty)| {
+            let dir = Direction::from_attack((actor_pos.x, actor_pos.y), (tx, ty));
+            let cover = world
+                .get_resource::<LevelMap>()
+                .map(|m| m.get_cover(tx, ty, dir))
+                .unwrap_or(CoverLevel::None);
+            let expected = calc_hit_chance(cover) * calc_damage(actor_attack, defense) as f32;
+            let dist = (tx - actor_pos.x).abs() + (ty - actor_pos.y).abs();
+            (e, expected, dist)
+        })
+        .max_by(|a, b| {
+            a.1.partial_cmp(&b.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(b.2.cmp(&a.2)) // prefer closer on tie
+        })
+        .map(|(e, _, _)| e)
+}
+
+/// Returns the best adjacent target (Chebyshev distance ≤ 1) for a melee attack.
+fn best_adjacent_target(targets: &[(Entity, i32, i32)], actor_pos: Position) -> Option<Entity> {
+    targets
+        .iter()
+        .filter(|&&(_, tx, ty)| {
+            let chebyshev = (actor_pos.x - tx).abs().max((actor_pos.y - ty).abs());
+            chebyshev <= 1 && chebyshev > 0
+        })
+        .map(|&(e, tx, ty)| {
+            let dist = (actor_pos.x - tx).abs() + (actor_pos.y - ty).abs();
+            (e, dist)
+        })
+        .min_by_key(|&(_, dist)| dist)
+        .map(|(e, _)| e)
+}
+
 /// Returns a `Move` action toward the best available cover tile.
 ///
-/// Phase 1 — reserve AP for attack: look for better cover within `ap - ATTACK_AP_COST` tiles.
+/// Phase 1 — reserve AP for attack: look for better cover within `ap - min_attack_cost` tiles.
 ///   If found, move there so the actor can still attack this turn.
 /// Phase 2 — advance toward cover: if no in-range cover exists, spend ALL AP to advance toward
 ///   the best reachable cover tile (skipping the attack this turn).
 /// Returns `None` only if already at Full cover or no better cover exists anywhere in range.
-fn seek_cover_action(world: &mut World, actor: Entity, turn: Turn, ap: i32) -> Option<Action> {
+fn seek_cover_action(
+    world: &mut World,
+    actor: Entity,
+    turn: Turn,
+    ap: i32,
+    min_attack_cost: i32,
+) -> Option<Action> {
     if ap == 0 {
         return None;
     }
@@ -498,7 +664,7 @@ fn seek_cover_action(world: &mut World, actor: Entity, turn: Turn, ap: i32) -> O
     candidates.sort_by(|a, b| b.3.cmp(&a.3).then(a.0.cmp(&b.0)));
 
     // Phase 1: prefer a tile reachable while keeping enough AP to attack after.
-    let attack_budget = ap - ATTACK_AP_COST;
+    let attack_budget = ap - min_attack_cost;
     if attack_budget > 0
         && let Some(&(_, tx, ty, _)) = candidates
             .iter()
@@ -513,50 +679,4 @@ fn seek_cover_action(world: &mut World, actor: Entity, turn: Turn, ap: i32) -> O
     candidates.first().map(|&(_, tx, ty, _)| Action::Move {
         destination: Position::new(tx, ty),
     })
-}
-
-/// Returns the entity that gives the highest expected damage (hit_chance × damage),
-/// preferring closer targets on ties.
-fn best_attack_target(world: &mut World, actor: Entity, turn: Turn) -> Option<Entity> {
-    let actor_pos = world.get::<Position>(actor).copied()?;
-    let actor_attack = world.get::<Stats>(actor).map(|s| s.attack).unwrap_or(0);
-
-    // Collect target data (drop query borrow before accessing resources).
-    let targets: Vec<(Entity, i32, i32, i32)> = match turn {
-        Turn::Player => {
-            let mut q = world.query::<(Entity, &Character, &Health, &Stats, &Position)>();
-            q.iter(world)
-                .filter(|(_, c, h, _, _)| {
-                    !c.kind.is_player() && c.aggression != Aggression::Friendly && h.is_alive()
-                })
-                .map(|(e, _, _, stats, pos)| (e, stats.defense, pos.x, pos.y))
-                .collect()
-        }
-        Turn::Enemy => {
-            let mut q = world.query::<(Entity, &Character, &Health, &Stats, &Position)>();
-            q.iter(world)
-                .filter(|(_, c, h, _, _)| c.kind.is_player() && h.is_alive())
-                .map(|(e, _, _, stats, pos)| (e, stats.defense, pos.x, pos.y))
-                .collect()
-        }
-    };
-
-    targets
-        .iter()
-        .map(|&(e, defense, tx, ty)| {
-            let dir = Direction::from_attack((actor_pos.x, actor_pos.y), (tx, ty));
-            let cover = world
-                .get_resource::<LevelMap>()
-                .map(|m| m.get_cover(tx, ty, dir))
-                .unwrap_or(CoverLevel::None);
-            let expected = calc_hit_chance(cover) * calc_damage(actor_attack, defense) as f32;
-            let dist = (tx - actor_pos.x).abs() + (ty - actor_pos.y).abs();
-            (e, expected, dist)
-        })
-        .max_by(|a, b| {
-            a.1.partial_cmp(&b.1)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then(b.2.cmp(&a.2)) // prefer closer on tie
-        })
-        .map(|(e, _, _)| e)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,30 +346,6 @@ fn render(world: &mut World, battle: &BattleStep, last: Option<&TurnEvent>) -> S
                 }
                 for action in &event.actions {
                     match action {
-                        TurnAction::Attack {
-                            target,
-                            damage,
-                            hit,
-                            cover,
-                        } => {
-                            let tname = entity_name(world, *target);
-                            let cover_str = match cover {
-                                CoverLevel::None => "",
-                                CoverLevel::Partial => " [partial cover]",
-                                CoverLevel::Full => " [full cover]",
-                            };
-                            if *hit {
-                                out += &format!(
-                                    "  > {} attacks {} for {} dmg{}\r\n",
-                                    name, tname, damage, cover_str
-                                );
-                            } else {
-                                out += &format!(
-                                    "  > {} attacks {} -- MISS{}\r\n",
-                                    name, tname, cover_str
-                                );
-                            }
-                        }
                         TurnAction::Move { to } => {
                             out += &format!("  > {} moves to ({}, {})\r\n", name, to.x, to.y);
                         }

--- a/src/player_input.rs
+++ b/src/player_input.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use bevy::prelude::*;
 
 use crate::{
+    ability::{Ability, AbilityEffect, AbilityKind, available_abilities},
     action_points::ActionPoints,
     character::{Aggression, Character},
     combat::{calc_damage, calc_hit_chance},
@@ -10,21 +11,22 @@ use crate::{
     position::Position,
     stats::Stats,
     terrain::{CoverLevel, Direction, LevelMap},
-    turn::{ATTACK_AP_COST, Action, MOVE_AP_COST},
+    turn::{Action, MOVE_AP_COST},
 };
 
 /// A fully-described action a player can choose for one of their combatants.
 #[derive(Debug, Clone)]
 pub enum PlayerActionChoice {
-    /// Attack a living enemy.
-    Attack {
-        target: Entity,
-        /// Probability of hitting, 0.0–1.0 (multiply by 100 for a percentage).
-        hit_chance: f32,
-        /// Damage dealt on a successful hit.
-        damage: i32,
-        /// Defender's cover level from this attack's direction.
-        cover: CoverLevel,
+    /// Use an ability — either offensive (targeting a living enemy) or utility (self/no target).
+    UseAbility {
+        ability: Ability,
+        target: Option<Entity>,
+        /// Pre-computed hit chance for offensive abilities; `None` for utility abilities.
+        hit_chance: Option<f32>,
+        /// Pre-computed damage for damage-dealing abilities; `None` for utility/disruption.
+        damage: Option<i32>,
+        /// Defender's cover level from this attack direction; `None` for utility or no-cover info.
+        cover: Option<CoverLevel>,
     },
     /// Move toward a tile offering better cover than the current position.
     MoveToCover {
@@ -42,7 +44,12 @@ impl PlayerActionChoice {
     /// Convert to the low-level [`Action`] consumed by [`crate::turn::apply_action`].
     pub fn to_action(&self) -> Action {
         match self {
-            Self::Attack { target, .. } => Action::Attack { target: *target },
+            Self::UseAbility {
+                ability, target, ..
+            } => Action::UseAbility {
+                ability: ability.clone(),
+                target: *target,
+            },
             Self::MoveToCover { destination, .. } => Action::Move {
                 destination: *destination,
             },
@@ -53,23 +60,38 @@ impl PlayerActionChoice {
     /// Short human-readable label suitable for a menu entry.
     pub fn display(&self) -> String {
         match self {
-            Self::Attack {
+            Self::UseAbility {
+                ability,
                 hit_chance,
                 damage,
                 cover,
                 ..
-            } => {
-                let pct = (hit_chance * 100.0).round() as i32;
-                match cover {
-                    CoverLevel::None => format!("Attack — {}% hit, {} dmg", pct, damage),
-                    CoverLevel::Partial => {
-                        format!("Attack — {}% hit, {} dmg (partial cover)", pct, damage)
-                    }
-                    CoverLevel::Full => {
-                        format!("Attack — {}% hit, {} dmg (full cover)", pct, damage)
+            } => match (hit_chance, damage) {
+                (Some(hc), Some(dmg)) => {
+                    let pct = (hc * 100.0).round() as i32;
+                    match cover.unwrap_or(CoverLevel::None) {
+                        CoverLevel::None => {
+                            format!(
+                                "{} — {}% hit, {} dmg ({}AP)",
+                                ability.name, pct, dmg, ability.ap_cost
+                            )
+                        }
+                        CoverLevel::Partial => {
+                            format!(
+                                "{} — {}% hit, {} dmg, partial cover ({}AP)",
+                                ability.name, pct, dmg, ability.ap_cost
+                            )
+                        }
+                        CoverLevel::Full => {
+                            format!(
+                                "{} — {}% hit, {} dmg, full cover ({}AP)",
+                                ability.name, pct, dmg, ability.ap_cost
+                            )
+                        }
                     }
                 }
-            }
+                _ => format!("{} ({}AP)", ability.name, ability.ap_cost),
+            },
             Self::MoveToCover { cover, ap_cost, .. } => {
                 let label = match cover {
                     CoverLevel::None => "open ground",
@@ -85,12 +107,14 @@ impl PlayerActionChoice {
 
 /// Returns all valid actions available to `actor` this turn given their remaining AP.
 ///
-/// Choices are grouped as follows:
-/// 1. One [`PlayerActionChoice::Attack`] per living enemy, each annotated with hit
-///    probability and expected damage (accounting for the defender's cover level).
-/// 2. Up to one [`PlayerActionChoice::MoveToCover`] per reachable cover level that
-///    is better than the actor's current cover, closest tile chosen for each level.
-/// 3. [`PlayerActionChoice::Pass`] (always present as the last entry).
+/// Choices are:
+/// 1. [`PlayerActionChoice::UseAbility`] for each offensive ability × each valid target:
+///    - Ranged abilities: one entry per living enemy.
+///    - Melee abilities: one entry per adjacent living enemy (Chebyshev distance ≤ 1,
+///      diagonals included).
+/// 2. [`PlayerActionChoice::UseAbility`] for each utility ability (self-targeted, once each).
+/// 3. Up to one [`PlayerActionChoice::MoveToCover`] per reachable cover level better than current.
+/// 4. [`PlayerActionChoice::Pass`] (always last).
 pub fn available_player_actions(world: &mut World, actor: Entity) -> Vec<PlayerActionChoice> {
     let mut choices = Vec::new();
 
@@ -102,13 +126,16 @@ pub fn available_player_actions(world: &mut World, actor: Entity) -> Vec<PlayerA
         Some(p) => p,
         None => return choices,
     };
-    let actor_attack = world.get::<Stats>(actor).map(|s| s.attack).unwrap_or(0);
 
-    // ── Attack options ─────────────────────────────────────────────────────────
-    if ap >= ATTACK_AP_COST {
-        // Collect target data before borrowing resources.
+    // ── Ability options ────────────────────────────────────────────────────────
+    if let Some(ch) = world.get::<Character>(actor) {
+        let level = ch.level;
+        let kind = ch.kind.clone();
+        let abilities = available_abilities(&kind, level);
+
+        // Collect living enemy data before further borrows.
         let mut q = world.query::<(Entity, &Character, &Health, &Stats, &Position)>();
-        let targets: Vec<(Entity, i32, i32, i32)> = q
+        let enemies: Vec<(Entity, i32, i32, i32)> = q
             .iter(world)
             .filter(|(_, c, h, _, _)| {
                 !c.kind.is_player() && c.aggression != Aggression::Friendly && h.is_alive()
@@ -116,20 +143,66 @@ pub fn available_player_actions(world: &mut World, actor: Entity) -> Vec<PlayerA
             .map(|(e, _, _, stats, pos)| (e, stats.defense, pos.x, pos.y))
             .collect();
 
-        for (target_entity, defense, tx, ty) in targets {
-            let dir = Direction::from_attack((actor_pos.x, actor_pos.y), (tx, ty));
-            let cover = world
-                .get_resource::<LevelMap>()
-                .map(|m| m.get_cover(tx, ty, dir))
-                .unwrap_or(CoverLevel::None);
-            let hit_chance = calc_hit_chance(cover);
-            let damage = calc_damage(actor_attack, defense);
-            choices.push(PlayerActionChoice::Attack {
-                target: target_entity,
-                hit_chance,
-                damage,
-                cover,
-            });
+        let actor_attack = world.get::<Stats>(actor).map(|s| s.attack).unwrap_or(0);
+
+        for ability in &abilities {
+            if ability.ap_cost > ap {
+                continue;
+            }
+            match &ability.kind {
+                AbilityKind::Ranged => {
+                    for &(target_entity, defense, tx, ty) in &enemies {
+                        let dir = Direction::from_attack((actor_pos.x, actor_pos.y), (tx, ty));
+                        let cover = world
+                            .get_resource::<LevelMap>()
+                            .map(|m| m.get_cover(tx, ty, dir))
+                            .unwrap_or(CoverLevel::None);
+                        let hit_chance = Some(calc_hit_chance(cover));
+                        let (damage, cover_opt) =
+                            offensive_damage(ability, actor_attack, defense, cover);
+                        choices.push(PlayerActionChoice::UseAbility {
+                            ability: ability.clone(),
+                            target: Some(target_entity),
+                            hit_chance,
+                            damage,
+                            cover: cover_opt,
+                        });
+                    }
+                }
+                AbilityKind::Melee => {
+                    // Only offer for adjacent targets (Chebyshev ≤ 1, diagonals included).
+                    for &(target_entity, defense, tx, ty) in &enemies {
+                        let chebyshev = (actor_pos.x - tx).abs().max((actor_pos.y - ty).abs());
+                        if chebyshev > 1 {
+                            continue;
+                        }
+                        let dir = Direction::from_attack((actor_pos.x, actor_pos.y), (tx, ty));
+                        let cover = world
+                            .get_resource::<LevelMap>()
+                            .map(|m| m.get_cover(tx, ty, dir))
+                            .unwrap_or(CoverLevel::None);
+                        let hit_chance = Some(calc_hit_chance(cover));
+                        let (damage, cover_opt) =
+                            offensive_damage(ability, actor_attack, defense, cover);
+                        choices.push(PlayerActionChoice::UseAbility {
+                            ability: ability.clone(),
+                            target: Some(target_entity),
+                            hit_chance,
+                            damage,
+                            cover: cover_opt,
+                        });
+                    }
+                }
+                AbilityKind::Utility => {
+                    choices.push(PlayerActionChoice::UseAbility {
+                        ability: ability.clone(),
+                        target: None,
+                        hit_chance: None,
+                        damage: None,
+                        cover: None,
+                    });
+                }
+            }
         }
     }
 
@@ -159,7 +232,6 @@ pub fn available_player_actions(world: &mut World, actor: Entity) -> Vec<PlayerA
                 .map(|m| m.get_cover(actor_pos.x, actor_pos.y, attack_dir))
                 .unwrap_or(CoverLevel::None);
 
-            // Collect candidate cover tiles within AP budget.
             let mut candidates: Vec<(CoverLevel, i32, i32, i32)> = Vec::new();
             if let Some(map) = world.get_resource::<LevelMap>() {
                 for dy in -ap..=ap {
@@ -185,7 +257,6 @@ pub fn available_player_actions(world: &mut World, actor: Entity) -> Vec<PlayerA
                 }
             }
 
-            // Best cover first, then closest. Emit one entry per cover level.
             candidates.sort_by(|a, b| b.0.cmp(&a.0).then(a.1.cmp(&b.1)));
             let mut seen: HashSet<u8> = HashSet::new();
             for (tile_cover, dist, tx, ty) in candidates {
@@ -202,4 +273,32 @@ pub fn available_player_actions(world: &mut World, actor: Entity) -> Vec<PlayerA
 
     choices.push(PlayerActionChoice::Pass);
     choices
+}
+
+/// Computes the pre-displayed damage and cover for an offensive ability choice.
+/// Returns `(damage, cover_opt)` — damage is `None` for non-damage effects.
+fn offensive_damage(
+    ability: &Ability,
+    actor_attack: i32,
+    defense: i32,
+    cover: CoverLevel,
+) -> (Option<i32>, Option<CoverLevel>) {
+    let cover_opt = Some(cover);
+    match &ability.effect {
+        AbilityEffect::BonusDamage { bonus } => {
+            (Some(calc_damage(actor_attack, defense) + bonus), cover_opt)
+        }
+        AbilityEffect::ArmorPiercing { pierce_fraction } => {
+            let eff = (defense as f32 * (1.0 - pierce_fraction)) as i32;
+            (Some(calc_damage(actor_attack, eff)), cover_opt)
+        }
+        AbilityEffect::ArmorPiercingStrike {
+            pierce_fraction,
+            bonus,
+        } => {
+            let eff = (defense as f32 * (1.0 - pierce_fraction)) as i32;
+            (Some(calc_damage(actor_attack, eff) + bonus), cover_opt)
+        }
+        _ => (None, None),
+    }
 }

--- a/src/turn.rs
+++ b/src/turn.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use crate::{
-    ability::{Ability, AbilityEffect},
+    ability::{Ability, AbilityEffect, AbilityKind},
     action_points::ActionPoints,
     combat::{calc_damage, calc_hit_chance, roll_hit},
     health::Health,
@@ -10,14 +10,11 @@ use crate::{
     terrain::{BattleRng, CoverLevel, Direction, LevelMap},
 };
 
-pub const ATTACK_AP_COST: i32 = 2;
 pub const MOVE_AP_COST: i32 = 1;
 
 /// An action a combatant can take on their turn, each costing AP.
 #[derive(Debug, Clone)]
 pub enum Action {
-    /// Attack a target entity. Costs `ATTACK_AP_COST` AP.
-    Attack { target: Entity },
     /// Move to a destination. Costs `MOVE_AP_COST` × Manhattan distance AP.
     Move { destination: Position },
     /// Use a class ability. `target` is required for targeted effects; `None` for self-targeted.
@@ -32,14 +29,6 @@ pub enum Action {
 /// One action that occurred during a combatant's turn (for the event log).
 #[derive(Debug, Clone)]
 pub enum TurnAction {
-    /// An attack was attempted. `hit` indicates whether it connected; `cover` is the
-    /// defender's cover level from this attack's direction.
-    Attack {
-        target: Entity,
-        damage: i32,
-        hit: bool,
-        cover: CoverLevel,
-    },
     Move {
         to: Position,
     },
@@ -54,70 +43,9 @@ pub enum TurnAction {
 
 /// Execute an action for `actor`.
 /// Returns `Some(TurnAction)` if the action was carried out, `None` if it
-/// was invalid (insufficient AP, dead target, blocked tile, etc.) or was Pass.
+/// was invalid (insufficient AP, dead target, blocked tile, out of melee range, etc.) or was Pass.
 pub fn apply_action(world: &mut World, actor: Entity, action: &Action) -> Option<TurnAction> {
     match action {
-        Action::Attack { target } => {
-            let ap = world
-                .get::<ActionPoints>(actor)
-                .map(|ap| ap.current)
-                .unwrap_or(0);
-            if ap < ATTACK_AP_COST {
-                return None;
-            }
-            if !world
-                .get::<Health>(*target)
-                .map(|h| h.is_alive())
-                .unwrap_or(false)
-            {
-                return None;
-            }
-
-            // Determine cover from defender's directional tile cover.
-            // resource_scope temporarily removes BattleRng to avoid borrow conflict.
-            let (hit, cover) = if world.get_resource::<BattleRng>().is_some() {
-                world.resource_scope(|world, mut rng: Mut<BattleRng>| {
-                    let attacker_pos = world.get::<Position>(actor).copied();
-                    let defender_pos = world.get::<Position>(*target).copied();
-                    let cover = match (attacker_pos, defender_pos) {
-                        (Some(ap), Some(dp)) => {
-                            let dir = Direction::from_attack((ap.x, ap.y), (dp.x, dp.y));
-                            world
-                                .get_resource::<LevelMap>()
-                                .map(|m| m.get_cover(dp.x, dp.y, dir))
-                                .unwrap_or(CoverLevel::None)
-                        }
-                        _ => CoverLevel::None,
-                    };
-                    let hit = roll_hit(calc_hit_chance(cover), &mut rng.0);
-                    (hit, cover)
-                })
-            } else {
-                (true, CoverLevel::None) // no RNG resource → always hit (simple unit tests)
-            };
-
-            let attack = world.get::<Stats>(actor).map(|s| s.attack).unwrap_or(0);
-            let defense = world.get::<Stats>(*target).map(|s| s.defense).unwrap_or(0);
-            let damage = if hit { calc_damage(attack, defense) } else { 0 };
-
-            world
-                .get_mut::<ActionPoints>(actor)
-                .unwrap()
-                .spend(ATTACK_AP_COST);
-            if hit {
-                world
-                    .get_mut::<Health>(*target)
-                    .unwrap()
-                    .take_damage(damage);
-            }
-
-            Some(TurnAction::Attack {
-                target: *target,
-                damage,
-                hit,
-                cover,
-            })
-        }
         Action::Move { destination } => {
             let current = match world.get::<Position>(actor) {
                 Some(p) => *p,
@@ -168,6 +96,24 @@ fn apply_ability(
         .unwrap_or(0);
     if ap < ability.ap_cost {
         return None;
+    }
+
+    // Enforce melee range: target must be within Chebyshev distance 1 (adjacent or diagonal).
+    // Only enforced when both actor and target have Position components.
+    if ability.kind == AbilityKind::Melee {
+        if let Some(target_entity) = target {
+            if let (Some(actor_pos), Some(target_pos)) = (
+                world.get::<Position>(actor).copied(),
+                world.get::<Position>(target_entity).copied(),
+            ) {
+                let chebyshev = (actor_pos.x - target_pos.x)
+                    .abs()
+                    .max((actor_pos.y - target_pos.y).abs());
+                if chebyshev > 1 {
+                    return None;
+                }
+            }
+        }
     }
 
     match &ability.effect {

--- a/tests/ability_tests.rs
+++ b/tests/ability_tests.rs
@@ -1,14 +1,37 @@
 use bevy::prelude::*;
 use carbonthrone::{
-    ability::{AbilityEffect, CharacterAbilities, available_abilities, character_abilities},
+    ability::{
+        AbilityEffect, AbilityKind, CharacterAbilities, available_abilities, character_abilities,
+    },
     action_points::ActionPoints,
     character::CharacterKind,
     health::Health,
+    position::Position,
     stats::Stats,
     turn::{Action, TurnAction, apply_action},
 };
 
 // ── Ability table tests ───────────────────────────────────────────────────────
+
+const ALL_NPC_KINDS: &[CharacterKind] = &[
+    CharacterKind::Zealot,
+    CharacterKind::Preacher,
+    CharacterKind::Purifier,
+    CharacterKind::Archon,
+    CharacterKind::Scavenger,
+    CharacterKind::VoidRaider,
+    CharacterKind::DrifterBoss,
+    CharacterKind::MaintenanceDrone,
+    CharacterKind::SecurityUnit,
+    CharacterKind::CombatFrame,
+    CharacterKind::MoonCrawler,
+    CharacterKind::VoidSpitter,
+    CharacterKind::AbyssalBrute,
+    CharacterKind::SalvageOperative,
+    CharacterKind::GunForHire,
+    CharacterKind::StationGuard,
+    CharacterKind::ShockTrooper,
+];
 
 #[test]
 fn each_character_has_three_abilities() {
@@ -376,4 +399,232 @@ fn greater_heal_restores_more_than_basic_heal() {
         _ => 0,
     };
     assert!(greater_amount > basic_amount);
+}
+
+// ── NPC ability coverage ──────────────────────────────────────────────────────
+
+#[test]
+fn all_npcs_have_at_least_one_ability() {
+    for kind in ALL_NPC_KINDS {
+        let abilities = character_abilities(kind);
+        assert!(
+            !abilities.is_empty(),
+            "{kind:?} should have at least one ability"
+        );
+    }
+}
+
+#[test]
+fn player_chars_have_at_most_one_melee_attack_and_one_ranged_weapon() {
+    for character in [
+        CharacterKind::Researcher,
+        CharacterKind::Orin,
+        CharacterKind::Doss,
+        CharacterKind::Kaleo,
+    ] {
+        let abilities = character_abilities(&character);
+        let melee_attacks = abilities
+            .iter()
+            .filter(|a| {
+                a.kind == AbilityKind::Melee
+                    && matches!(
+                        a.effect,
+                        AbilityEffect::BonusDamage { .. }
+                            | AbilityEffect::ArmorPiercing { .. }
+                            | AbilityEffect::ArmorPiercingStrike { .. }
+                    )
+            })
+            .count();
+        let ranged_weapons = abilities
+            .iter()
+            .filter(|a| {
+                a.kind == AbilityKind::Ranged
+                    && matches!(
+                        a.effect,
+                        AbilityEffect::BonusDamage { .. }
+                            | AbilityEffect::ArmorPiercing { .. }
+                            | AbilityEffect::ArmorPiercingStrike { .. }
+                    )
+            })
+            .count();
+        assert!(
+            melee_attacks <= 1,
+            "{character:?} has {melee_attacks} melee attacks (max 1)"
+        );
+        assert!(
+            ranged_weapons <= 1,
+            "{character:?} has {ranged_weapons} ranged weapons (max 1)"
+        );
+    }
+}
+
+#[test]
+fn npc_chars_have_at_most_one_melee_attack_and_one_ranged_weapon() {
+    for kind in ALL_NPC_KINDS {
+        let abilities = character_abilities(kind);
+        let melee_attacks = abilities
+            .iter()
+            .filter(|a| {
+                a.kind == AbilityKind::Melee
+                    && matches!(
+                        a.effect,
+                        AbilityEffect::BonusDamage { .. }
+                            | AbilityEffect::ArmorPiercing { .. }
+                            | AbilityEffect::ArmorPiercingStrike { .. }
+                    )
+            })
+            .count();
+        let ranged_weapons = abilities
+            .iter()
+            .filter(|a| {
+                a.kind == AbilityKind::Ranged
+                    && matches!(
+                        a.effect,
+                        AbilityEffect::BonusDamage { .. }
+                            | AbilityEffect::ArmorPiercing { .. }
+                            | AbilityEffect::ArmorPiercingStrike { .. }
+                    )
+            })
+            .count();
+        assert!(
+            melee_attacks <= 1,
+            "{kind:?} has {melee_attacks} melee attacks (max 1)"
+        );
+        assert!(
+            ranged_weapons <= 1,
+            "{kind:?} has {ranged_weapons} ranged weapons (max 1)"
+        );
+    }
+}
+
+// ── AbilityKind field tests ───────────────────────────────────────────────────
+
+#[test]
+fn all_abilities_have_kind_field() {
+    for character in [
+        CharacterKind::Researcher,
+        CharacterKind::Orin,
+        CharacterKind::Doss,
+        CharacterKind::Kaleo,
+    ] {
+        for ability in character_abilities(&character) {
+            // Just accessing .kind confirms the field exists and is set.
+            let _ = &ability.kind;
+        }
+    }
+}
+
+// ── Melee range enforcement ───────────────────────────────────────────────────
+
+#[test]
+fn melee_ability_blocked_when_not_adjacent() {
+    let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Doss, 1)
+        .into_iter()
+        .find(|a| a.name == "Power Strike")
+        .unwrap();
+    assert_eq!(ability.kind, AbilityKind::Melee);
+
+    let attacker = world
+        .spawn((stats(10, 5), ActionPoints::new(4), Position::new(0, 0)))
+        .id();
+    let target = world
+        .spawn((stats(5, 0), Health::new(100), Position::new(5, 0)))
+        .id();
+
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
+    assert!(
+        result.is_none(),
+        "melee must fail when Chebyshev distance > 1"
+    );
+    assert_eq!(world.get::<Health>(target).unwrap().current, 100);
+}
+
+#[test]
+fn melee_ability_succeeds_adjacent_orthogonal() {
+    let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Doss, 1)
+        .into_iter()
+        .find(|a| a.name == "Power Strike")
+        .unwrap();
+
+    let attacker = world
+        .spawn((stats(10, 5), ActionPoints::new(4), Position::new(0, 0)))
+        .id();
+    let target = world
+        .spawn((stats(5, 0), Health::new(100), Position::new(1, 0)))
+        .id();
+
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
+    assert!(
+        result.is_some(),
+        "melee must succeed at orthogonal distance 1"
+    );
+}
+
+#[test]
+fn melee_ability_succeeds_adjacent_diagonal() {
+    let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Doss, 1)
+        .into_iter()
+        .find(|a| a.name == "Power Strike")
+        .unwrap();
+
+    let attacker = world
+        .spawn((stats(10, 5), ActionPoints::new(4), Position::new(0, 0)))
+        .id();
+    let target = world
+        .spawn((stats(5, 0), Health::new(100), Position::new(1, 1)))
+        .id();
+
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
+    assert!(result.is_some(), "melee must allow diagonal adjacency");
+}
+
+#[test]
+fn ranged_ability_succeeds_at_any_range() {
+    let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Kaleo, 1)
+        .into_iter()
+        .find(|a| a.name == "Aimed Shot")
+        .unwrap();
+    assert_eq!(ability.kind, AbilityKind::Ranged);
+
+    let attacker = world
+        .spawn((stats(10, 5), ActionPoints::new(4), Position::new(0, 0)))
+        .id();
+    let target = world
+        .spawn((stats(5, 0), Health::new(100), Position::new(50, 50)))
+        .id();
+
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
+    assert!(result.is_some(), "ranged ability must work at any range");
 }

--- a/tests/player_input_tests.rs
+++ b/tests/player_input_tests.rs
@@ -14,8 +14,9 @@ use carbonthrone::{
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
+/// Spawns a Kaleo player (ranged abilities → no adjacency requirement for attack tests).
 fn spawn_player(world: &mut World, pos: (i32, i32), attack: i32, defense: i32) -> Entity {
-    let ch = Character::new_character(CharacterKind::Doss, 1);
+    let ch = Character::new_character(CharacterKind::Kaleo, 1);
     world
         .spawn((
             ch,
@@ -61,35 +62,50 @@ fn always_ends_with_pass() {
 }
 
 #[test]
-fn attack_choice_listed_for_each_living_enemy() {
+fn ability_choice_listed_for_each_living_enemy() {
     let mut world = World::new();
     let actor = spawn_player(&mut world, (0, 0), 10, 5);
     spawn_enemy(&mut world, (5, 0), 4);
     spawn_enemy(&mut world, (0, 5), 2);
 
     let choices = available_player_actions(&mut world, actor);
-    let attacks: Vec<_> = choices
+    // Kaleo at level 1 has one ranged ability (Aimed Shot): one UseAbility per enemy.
+    let ability_choices: Vec<_> = choices
         .iter()
-        .filter(|c| matches!(c, PlayerActionChoice::Attack { .. }))
+        .filter(|c| {
+            matches!(
+                c,
+                PlayerActionChoice::UseAbility {
+                    target: Some(_),
+                    ..
+                }
+            )
+        })
         .collect();
-    assert_eq!(attacks.len(), 2, "one attack choice per living enemy");
+    assert_eq!(
+        ability_choices.len(),
+        2,
+        "one ability choice per living enemy"
+    );
 }
 
 #[test]
-fn attack_choice_has_correct_hit_chance_no_cover() {
+fn ability_choice_has_correct_hit_chance_no_cover() {
     let mut world = World::new();
     let actor = spawn_player(&mut world, (0, 0), 10, 5);
     spawn_enemy(&mut world, (5, 0), 4);
 
     let choices = available_player_actions(&mut world, actor);
     for choice in &choices {
-        if let PlayerActionChoice::Attack {
-            hit_chance, cover, ..
+        if let PlayerActionChoice::UseAbility {
+            hit_chance: Some(hc),
+            cover: Some(cover),
+            ..
         } = choice
         {
             assert_eq!(*cover, CoverLevel::None);
             assert!(
-                (hit_chance - BASE_HIT_CHANCE).abs() < 0.001,
+                (hc - BASE_HIT_CHANCE).abs() < 0.001,
                 "no-cover hit chance should be {BASE_HIT_CHANCE}"
             );
         }
@@ -97,30 +113,31 @@ fn attack_choice_has_correct_hit_chance_no_cover() {
 }
 
 #[test]
-fn attack_choice_reflects_partial_cover() {
+fn ability_choice_reflects_partial_cover() {
     // Target at (5,5); obstacle diagonally from North-West → partial cover from West.
     let mut world = World::new();
     let actor = spawn_player(&mut world, (0, 5), 10, 5); // attacker approaches from West
     spawn_enemy(&mut world, (5, 5), 4);
 
     let mut map = LevelMap::new(10, 10, ZoneKind::CommandDeck);
-    // Obstacle at (4,4) — diagonal neighbor of (5,5) from the west direction.
     map.set(4, 4, Tile::Obstacle);
     map.recompute_cover();
     world.insert_resource(map);
 
     let choices = available_player_actions(&mut world, actor);
-    let attack_opt = choices.iter().find_map(|c| {
-        if let PlayerActionChoice::Attack {
-            hit_chance, cover, ..
+    let ability_opt = choices.iter().find_map(|c| {
+        if let PlayerActionChoice::UseAbility {
+            hit_chance: Some(hc),
+            cover: Some(cover),
+            ..
         } = c
         {
-            Some((*hit_chance, *cover))
+            Some((*hc, *cover))
         } else {
             None
         }
     });
-    let (hit_chance, cover) = attack_opt.expect("expected an attack choice");
+    let (hit_chance, cover) = ability_opt.expect("expected an ability choice with cover info");
     assert_eq!(cover, CoverLevel::Partial);
     assert!(
         (hit_chance - 0.65).abs() < 0.001,
@@ -129,7 +146,7 @@ fn attack_choice_reflects_partial_cover() {
 }
 
 #[test]
-fn attack_choice_reflects_full_cover() {
+fn ability_choice_reflects_full_cover() {
     // Target at (5,5); obstacle directly north at (5,4) — Full cover from North.
     let mut world = World::new();
     let actor = spawn_player(&mut world, (5, 0), 10, 5); // approaches from North
@@ -144,16 +161,18 @@ fn attack_choice_reflects_full_cover() {
     let (hit_chance, cover) = choices
         .iter()
         .find_map(|c| {
-            if let PlayerActionChoice::Attack {
-                hit_chance, cover, ..
+            if let PlayerActionChoice::UseAbility {
+                hit_chance: Some(hc),
+                cover: Some(cover),
+                ..
             } = c
             {
-                Some((*hit_chance, *cover))
+                Some((*hc, *cover))
             } else {
                 None
             }
         })
-        .expect("expected an attack choice");
+        .expect("expected an ability choice with cover info");
 
     assert_eq!(cover, CoverLevel::Full);
     assert!(
@@ -163,8 +182,8 @@ fn attack_choice_reflects_full_cover() {
 }
 
 #[test]
-fn attack_choice_reflects_correct_damage() {
-    // calc_damage(attack=10, defense=4) = 10 - 4/2 = 8
+fn ability_choice_reflects_correct_damage() {
+    // Kaleo Aimed Shot: calc_damage(attack=10, defense=4) + bonus 5 = 8 + 5 = 13
     let mut world = World::new();
     let actor = spawn_player(&mut world, (0, 0), 10, 5);
     spawn_enemy(&mut world, (5, 0), 4);
@@ -173,20 +192,23 @@ fn attack_choice_reflects_correct_damage() {
     let damage = choices
         .iter()
         .find_map(|c| {
-            if let PlayerActionChoice::Attack { damage, .. } = c {
-                Some(*damage)
+            if let PlayerActionChoice::UseAbility {
+                damage: Some(dmg), ..
+            } = c
+            {
+                Some(*dmg)
             } else {
                 None
             }
         })
-        .expect("expected attack choice");
-    assert_eq!(damage, 8);
+        .expect("expected ability choice with damage");
+    assert_eq!(damage, 13); // calc_damage(10,4)=8, +5 bonus = 13
 }
 
 #[test]
-fn no_attack_choices_when_ap_too_low() {
+fn no_ability_choices_when_no_character_component() {
     let mut world = World::new();
-    // Actor with only 1 AP — ATTACK_AP_COST is 2, so no attacks should appear.
+    // Actor without a Character component → no abilities offered.
     let actor = world
         .spawn((
             Health::new(100),
@@ -206,7 +228,130 @@ fn no_attack_choices_when_ap_too_low() {
     assert!(
         !choices
             .iter()
-            .any(|c| matches!(c, PlayerActionChoice::Attack { .. }))
+            .any(|c| matches!(c, PlayerActionChoice::UseAbility { .. }))
+    );
+}
+
+#[test]
+fn melee_ability_not_offered_when_target_not_adjacent() {
+    // Doss has melee abilities only; enemy is far away → no offensive UseAbility choices.
+    let mut world = World::new();
+    let ch = Character::new_character(CharacterKind::Doss, 1);
+    let actor = world
+        .spawn((
+            ch,
+            Health::new(100),
+            Stats {
+                max_hp: 100,
+                attack: 10,
+                defense: 5,
+                speed: 10,
+            },
+            ActionPoints::new(4),
+            Position::new(0, 0),
+        ))
+        .id();
+    spawn_enemy(&mut world, (5, 0), 4); // not adjacent
+
+    let choices = available_player_actions(&mut world, actor);
+    let offensive: Vec<_> = choices
+        .iter()
+        .filter(|c| {
+            matches!(
+                c,
+                PlayerActionChoice::UseAbility {
+                    target: Some(_),
+                    damage: Some(_),
+                    ..
+                }
+            )
+        })
+        .collect();
+    assert!(
+        offensive.is_empty(),
+        "melee abilities should not be offered for non-adjacent targets"
+    );
+}
+
+#[test]
+fn melee_ability_offered_when_target_adjacent() {
+    // Doss has melee abilities; enemy is adjacent (distance 1) → UseAbility offered.
+    let mut world = World::new();
+    let ch = Character::new_character(CharacterKind::Doss, 1);
+    let actor = world
+        .spawn((
+            ch,
+            Health::new(100),
+            Stats {
+                max_hp: 100,
+                attack: 10,
+                defense: 5,
+                speed: 10,
+            },
+            ActionPoints::new(4),
+            Position::new(0, 0),
+        ))
+        .id();
+    spawn_enemy(&mut world, (1, 0), 4); // adjacent
+
+    let choices = available_player_actions(&mut world, actor);
+    let offensive: Vec<_> = choices
+        .iter()
+        .filter(|c| {
+            matches!(
+                c,
+                PlayerActionChoice::UseAbility {
+                    target: Some(_),
+                    damage: Some(_),
+                    ..
+                }
+            )
+        })
+        .collect();
+    assert!(
+        !offensive.is_empty(),
+        "melee abilities should be offered for adjacent targets"
+    );
+}
+
+#[test]
+fn melee_ability_offered_for_diagonal_adjacency() {
+    // Diagonal adjacency: Chebyshev distance = max(1,1) = 1.
+    let mut world = World::new();
+    let ch = Character::new_character(CharacterKind::Doss, 1);
+    let actor = world
+        .spawn((
+            ch,
+            Health::new(100),
+            Stats {
+                max_hp: 100,
+                attack: 10,
+                defense: 5,
+                speed: 10,
+            },
+            ActionPoints::new(4),
+            Position::new(0, 0),
+        ))
+        .id();
+    spawn_enemy(&mut world, (1, 1), 4); // diagonal
+
+    let choices = available_player_actions(&mut world, actor);
+    let offensive: Vec<_> = choices
+        .iter()
+        .filter(|c| {
+            matches!(
+                c,
+                PlayerActionChoice::UseAbility {
+                    target: Some(_),
+                    damage: Some(_),
+                    ..
+                }
+            )
+        })
+        .collect();
+    assert!(
+        !offensive.is_empty(),
+        "melee abilities should allow diagonal adjacency"
     );
 }
 
@@ -300,7 +445,7 @@ fn display_strings_are_non_empty() {
 fn player_choices_returns_options_on_player_turn() {
     let mut world = World::new();
     world.spawn((
-        Character::new_character(CharacterKind::Doss, 1),
+        Character::new_character(CharacterKind::Kaleo, 1),
         Health::new(100),
         Stats {
             max_hp: 100,
@@ -330,7 +475,7 @@ fn player_choices_returns_options_on_player_turn() {
     assert!(
         choices
             .iter()
-            .any(|c| matches!(c, PlayerActionChoice::Attack { .. }))
+            .any(|c| matches!(c, PlayerActionChoice::UseAbility { .. }))
     );
     assert!(
         choices
@@ -344,7 +489,7 @@ fn step_player_action_pass_ends_turn() {
     let mut world = World::new();
     let player = world
         .spawn((
-            Character::new_character(CharacterKind::Doss, 1),
+            Character::new_character(CharacterKind::Kaleo, 1),
             Health::new(100),
             Stats {
                 max_hp: 100,
@@ -379,10 +524,10 @@ fn step_player_action_pass_ends_turn() {
 }
 
 #[test]
-fn step_player_action_attack_deals_damage() {
+fn step_player_action_ability_deals_damage() {
     let mut world = World::new();
     world.spawn((
-        Character::new_character(CharacterKind::Doss, 1),
+        Character::new_character(CharacterKind::Kaleo, 1),
         Health::new(100),
         Stats {
             max_hp: 100,
@@ -411,15 +556,21 @@ fn step_player_action_attack_deals_damage() {
     let mut bs = BattleStep::new(&mut world);
     let choices = bs.player_choices(&mut world);
 
-    // Pick the attack choice targeting the enemy.
-    let attack_choice = choices
+    let ability_choice = choices
         .iter()
-        .find(|c| matches!(c, PlayerActionChoice::Attack { .. }))
-        .expect("expected an attack choice");
+        .find(|c| {
+            matches!(
+                c,
+                PlayerActionChoice::UseAbility {
+                    target: Some(_),
+                    ..
+                }
+            )
+        })
+        .expect("expected a UseAbility choice");
 
-    bs.step_player_action(&mut world, attack_choice);
+    bs.step_player_action(&mut world, ability_choice);
 
-    // Enemy should have taken damage (no BattleRng → always hits).
     let hp = world.get::<Health>(enemy).unwrap().current;
     assert!(hp < 50, "enemy should have taken damage");
 }
@@ -428,7 +579,7 @@ fn step_player_action_attack_deals_damage() {
 fn step_player_action_outcome_set_on_victory() {
     let mut world = World::new();
     world.spawn((
-        Character::new_character(CharacterKind::Doss, 1),
+        Character::new_character(CharacterKind::Kaleo, 1),
         Health::new(100),
         Stats {
             max_hp: 100,
@@ -454,11 +605,19 @@ fn step_player_action_outcome_set_on_victory() {
 
     let mut bs = BattleStep::new(&mut world);
     let choices = bs.player_choices(&mut world);
-    let attack = choices
+    let ability_choice = choices
         .iter()
-        .find(|c| matches!(c, PlayerActionChoice::Attack { .. }))
+        .find(|c| {
+            matches!(
+                c,
+                PlayerActionChoice::UseAbility {
+                    target: Some(_),
+                    ..
+                }
+            )
+        })
         .unwrap();
 
-    let result = bs.step_player_action(&mut world, attack);
+    let result = bs.step_player_action(&mut world, ability_choice);
     assert_eq!(result.outcome, Some(BattleOutcome::PlayerVictory));
 }

--- a/tests/simulation_tests.rs
+++ b/tests/simulation_tests.rs
@@ -37,7 +37,8 @@ fn enemy(world: &mut World, hp: i32, attack: i32, defense: i32, speed: i32) -> E
                 speed,
             },
             ActionPoints::new(4),
-            Position::new(5, 0),
+            // Place adjacent to player at (0,0) so melee abilities are in range.
+            Position::new(1, 0),
         ))
         .id()
 }

--- a/tests/turn_tests.rs
+++ b/tests/turn_tests.rs
@@ -1,11 +1,13 @@
 use bevy::prelude::*;
 use carbonthrone::{
+    ability::available_abilities,
     action_points::ActionPoints,
+    character::CharacterKind,
     health::Health,
     position::Position,
     stats::Stats,
     terrain::{BattleRng, LevelMap, Tile},
-    turn::{ATTACK_AP_COST, Action, MOVE_AP_COST, TurnAction, apply_action},
+    turn::{Action, MOVE_AP_COST, TurnAction, apply_action},
     zone::ZoneKind,
 };
 use rand::SeedableRng;
@@ -20,32 +22,59 @@ fn stats(attack: i32, defense: i32) -> Stats {
     }
 }
 
-// ── Existing action tests (updated for Option<TurnAction> return) ──────────
+// ── UseAbility action tests ────────────────────────────────────────────────
 
 #[test]
-fn attack_reduces_target_hp_and_spends_ap() {
+fn ranged_ability_reduces_target_hp_and_spends_ap() {
     let mut world = World::new();
+    // Aimed Shot: Ranged, ap_cost 2, BonusDamage { bonus: 5 }
+    let ability = available_abilities(&CharacterKind::Kaleo, 1)
+        .into_iter()
+        .find(|a| a.name == "Aimed Shot")
+        .unwrap();
+    assert_eq!(ability.ap_cost, 2);
+
+    // No BattleRng → always hits. calc_damage(10, 4) + 5 = 13.
     let attacker = world.spawn((stats(10, 5), ActionPoints::new(4))).id();
-    // No BattleRng → always hits. calc_damage(10, 4) = 8.
     let target = world.spawn((stats(5, 4), Health::new(50))).id();
 
-    let result = apply_action(&mut world, attacker, &Action::Attack { target });
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability: ability.clone(),
+            target: Some(target),
+        },
+    );
 
     assert!(result.is_some());
-    assert_eq!(world.get::<Health>(target).unwrap().current, 42);
+    assert_eq!(world.get::<Health>(target).unwrap().current, 37); // 50 - 13
     assert_eq!(
         world.get::<ActionPoints>(attacker).unwrap().current,
-        4 - ATTACK_AP_COST
+        4 - ability.ap_cost
     );
 }
 
 #[test]
-fn attack_fails_without_enough_ap() {
+fn ability_fails_without_enough_ap() {
     let mut world = World::new();
-    let attacker = world.spawn((stats(10, 5), ActionPoints::new(1))).id();
+    let ability = available_abilities(&CharacterKind::Kaleo, 1)
+        .into_iter()
+        .find(|a| a.name == "Aimed Shot")
+        .unwrap();
+    assert_eq!(ability.ap_cost, 2);
+
+    let attacker = world.spawn((stats(10, 5), ActionPoints::new(1))).id(); // only 1 AP
     let target = world.spawn((stats(5, 4), Health::new(50))).id();
 
-    let result = apply_action(&mut world, attacker, &Action::Attack { target });
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
 
     assert!(result.is_none());
     assert_eq!(world.get::<Health>(target).unwrap().current, 50);
@@ -53,16 +82,153 @@ fn attack_fails_without_enough_ap() {
 }
 
 #[test]
-fn attack_on_dead_target_fails() {
+fn ability_on_dead_target_fails() {
     let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Kaleo, 1)
+        .into_iter()
+        .find(|a| a.name == "Aimed Shot")
+        .unwrap();
+
     let attacker = world.spawn((stats(10, 5), ActionPoints::new(4))).id();
     let mut target_hp = Health::new(50);
     target_hp.take_damage(50); // kill it
     let target = world.spawn((stats(5, 4), target_hp)).id();
 
-    let result = apply_action(&mut world, attacker, &Action::Attack { target });
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
 
     assert!(result.is_none());
+}
+
+#[test]
+fn melee_ability_blocked_when_target_not_adjacent() {
+    let mut world = World::new();
+    // Power Strike: Melee, ap_cost 3
+    let ability = available_abilities(&CharacterKind::Doss, 1)
+        .into_iter()
+        .find(|a| a.name == "Power Strike")
+        .unwrap();
+
+    // Chebyshev distance = 5 → not adjacent → should fail.
+    let attacker = world
+        .spawn((stats(10, 5), ActionPoints::new(4), Position::new(0, 0)))
+        .id();
+    let target = world
+        .spawn((stats(5, 4), Health::new(50), Position::new(5, 0)))
+        .id();
+
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
+
+    assert!(
+        result.is_none(),
+        "melee ability should fail when not adjacent"
+    );
+    assert_eq!(world.get::<Health>(target).unwrap().current, 50);
+    assert_eq!(world.get::<ActionPoints>(attacker).unwrap().current, 4);
+}
+
+#[test]
+fn melee_ability_succeeds_when_adjacent() {
+    let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Doss, 1)
+        .into_iter()
+        .find(|a| a.name == "Power Strike")
+        .unwrap();
+
+    // Chebyshev distance = 1 → adjacent → should succeed.
+    let attacker = world
+        .spawn((stats(10, 5), ActionPoints::new(4), Position::new(0, 0)))
+        .id();
+    let target = world
+        .spawn((stats(5, 4), Health::new(50), Position::new(1, 0)))
+        .id();
+
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
+
+    assert!(
+        result.is_some(),
+        "melee ability should succeed when adjacent"
+    );
+    assert!(world.get::<Health>(target).unwrap().current < 50);
+}
+
+#[test]
+fn melee_ability_succeeds_on_diagonal() {
+    let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Doss, 1)
+        .into_iter()
+        .find(|a| a.name == "Power Strike")
+        .unwrap();
+
+    // Diagonal adjacency: Chebyshev distance = max(1,1) = 1.
+    let attacker = world
+        .spawn((stats(10, 5), ActionPoints::new(4), Position::new(0, 0)))
+        .id();
+    let target = world
+        .spawn((stats(5, 4), Health::new(50), Position::new(1, 1)))
+        .id();
+
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
+
+    assert!(
+        result.is_some(),
+        "melee ability should allow diagonal adjacency"
+    );
+    assert!(world.get::<Health>(target).unwrap().current < 50);
+}
+
+#[test]
+fn ranged_ability_works_without_positions() {
+    // Ranged abilities have no positional restriction; no Position components needed.
+    let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Kaleo, 1)
+        .into_iter()
+        .find(|a| a.name == "Aimed Shot")
+        .unwrap();
+
+    let attacker = world.spawn((stats(10, 5), ActionPoints::new(4))).id();
+    let target = world.spawn((stats(5, 4), Health::new(50))).id();
+
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
+
+    assert!(
+        result.is_some(),
+        "ranged ability should work without Position components"
+    );
 }
 
 #[test]
@@ -151,7 +317,6 @@ fn move_to_obstacle_is_blocked() {
 
     assert!(result.is_none());
     assert_eq!(world.get::<Position>(mover).unwrap().x, 0); // unchanged
-    // AP should NOT have been spent
     assert_eq!(world.get::<ActionPoints>(mover).unwrap().current, 4);
 }
 
@@ -161,6 +326,7 @@ fn move_to_obstacle_is_blocked() {
 /// Attacker at (5,0) → attack direction North → obstacle at (5,4) provides Full cover.
 fn seeded_world_with_full_cover(seed: u64) -> (World, Entity, Entity) {
     let mut world = World::new();
+    // Use Aimed Shot (Ranged) so no adjacency requirement.
     let attacker = world
         .spawn((stats(10, 0), ActionPoints::new(4), Position::new(5, 0)))
         .id();
@@ -178,41 +344,61 @@ fn seeded_world_with_full_cover(seed: u64) -> (World, Entity, Entity) {
 }
 
 #[test]
-fn attack_hit_on_open_tile_deals_damage() {
+fn ability_hit_on_open_tile_deals_damage() {
     // No LevelMap → CoverLevel::None by default → 90% hit chance.
-    // seed 0 with StdRng will almost certainly hit.
     let mut world = World::new();
+    let ability = available_abilities(&CharacterKind::Kaleo, 1)
+        .into_iter()
+        .find(|a| a.name == "Aimed Shot")
+        .unwrap();
+
     let attacker = world.spawn((stats(10, 0), ActionPoints::new(4))).id();
     let target = world
         .spawn((stats(0, 0), Health::new(100), Position::new(5, 5)))
         .id();
     world.insert_resource(BattleRng(StdRng::seed_from_u64(0)));
 
-    let result = apply_action(&mut world, attacker, &Action::Attack { target });
+    let result = apply_action(
+        &mut world,
+        attacker,
+        &Action::UseAbility {
+            ability,
+            target: Some(target),
+        },
+    );
 
     match result.unwrap() {
-        TurnAction::Attack { hit, damage, .. } => {
+        TurnAction::UseAbility { hit, value, .. } => {
             if hit {
-                assert!(damage > 0);
+                assert!(value > 0);
                 assert!(world.get::<Health>(target).unwrap().current < 100);
             }
-            // If miss (unlikely with 90% chance on seed 0), just verify no damage dealt
         }
-        _ => panic!("expected Attack result"),
+        _ => panic!("expected UseAbility result"),
     }
 }
 
 #[test]
-fn attack_miss_does_not_deal_damage() {
+fn ability_miss_does_not_deal_damage() {
     // Full cover → 35% hit chance; scan seeds until we find a miss.
+    let ability = available_abilities(&CharacterKind::Kaleo, 1)
+        .into_iter()
+        .find(|a| a.name == "Aimed Shot")
+        .unwrap();
+
     let mut saw_miss = false;
     for seed in 0..200u64 {
         let (mut world, attacker, target) = seeded_world_with_full_cover(seed);
         let hp_before = world.get::<Health>(target).unwrap().current;
 
-        if let Some(TurnAction::Attack { hit, .. }) =
-            apply_action(&mut world, attacker, &Action::Attack { target })
-        {
+        if let Some(TurnAction::UseAbility { hit, .. }) = apply_action(
+            &mut world,
+            attacker,
+            &Action::UseAbility {
+                ability: ability.clone(),
+                target: Some(target),
+            },
+        ) {
             if !hit {
                 saw_miss = true;
                 let hp_after = world.get::<Health>(target).unwrap().current;
@@ -230,16 +416,27 @@ fn attack_miss_does_not_deal_damage() {
 #[test]
 fn ap_spent_on_miss() {
     // Full cover; confirm AP is still spent even on a miss.
+    let ability = available_abilities(&CharacterKind::Kaleo, 1)
+        .into_iter()
+        .find(|a| a.name == "Aimed Shot")
+        .unwrap();
+    let ap_cost = ability.ap_cost;
+
     for seed in 0..200u64 {
         let (mut world, attacker, target) = seeded_world_with_full_cover(seed);
 
-        if let Some(TurnAction::Attack { hit, .. }) =
-            apply_action(&mut world, attacker, &Action::Attack { target })
-        {
+        if let Some(TurnAction::UseAbility { hit, .. }) = apply_action(
+            &mut world,
+            attacker,
+            &Action::UseAbility {
+                ability: ability.clone(),
+                target: Some(target),
+            },
+        ) {
             if !hit {
                 assert_eq!(
                     world.get::<ActionPoints>(attacker).unwrap().current,
-                    4 - ATTACK_AP_COST
+                    4 - ap_cost
                 );
                 return;
             }


### PR DESCRIPTION
- Add AbilityKind (Melee/Ranged/Utility) to ability system
- Add abilities for all 17 NPC kinds based on characters.md and npcs.md lore
- Remove generic Attack action and ATTACK_AP_COST
- Enforce melee attacks only when adjacent (Chebyshev <= 1, diagonals allowed)
- At most one melee attack and one ranged weapon per character
- AI selects abilities instead of generic attack action
- Update all tests to use ability-based combat

Fixes #14