### PR TITLE
feat: implement loop-aware random encounter system

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -326,6 +326,64 @@ pub(crate) fn default_aggression(kind: &CharacterKind) -> Aggression {
     }
 }
 
+/// Returns the aggression state for a character kind at the given loop number.
+///
+/// Aggression evolves over loops as the station degrades and temporal instability peaks:
+/// - **Maintenance Drones**: Neutral loops 1–2; Aggressive loop 3+
+/// - **Station Guards**: Friendly loops 1–2; Neutral loop 3; Aggressive loops 4–5
+/// - **Salvage Operatives**: Friendly loops 1–2; Neutral loop 3; Aggressive loops 4–5
+/// - **Gun-for-Hire**: Neutral loops 1–4; Aggressive loop 5 (Doss turns them)
+/// - **Abyssal Fauna** (Moon Crawler, Void Spitter, Abyssal Brute): Aggressive loops 1–3;
+///   Lethargic loops 4–5 (temporal flux collapses their instincts)
+/// - All other kinds return their default aggression unchanged.
+pub fn loop_aggression(kind: &CharacterKind, loop_number: u32) -> Aggression {
+    match kind {
+        // Automata — Maintenance Drones go hostile as station degrades
+        CharacterKind::MaintenanceDrone => {
+            if loop_number >= 3 {
+                Aggression::Aggressive
+            } else {
+                Aggression::Neutral
+            }
+        }
+        // Station Personnel — flip from friendly to hostile over loops
+        CharacterKind::StationGuard => {
+            if loop_number <= 2 {
+                Aggression::Friendly
+            } else if loop_number == 3 {
+                Aggression::Neutral
+            } else {
+                Aggression::Aggressive
+            }
+        }
+        CharacterKind::SalvageOperative => {
+            if loop_number <= 2 {
+                Aggression::Friendly
+            } else if loop_number == 3 {
+                Aggression::Neutral
+            } else {
+                Aggression::Aggressive
+            }
+        }
+        CharacterKind::GunForHire => {
+            if loop_number >= 5 {
+                Aggression::Aggressive
+            } else {
+                Aggression::Neutral
+            }
+        }
+        // Abyssal Fauna — go Lethargic in loops 4–5 as temporal flux peaks
+        CharacterKind::MoonCrawler | CharacterKind::VoidSpitter | CharacterKind::AbyssalBrute => {
+            if loop_number >= 4 {
+                Aggression::Lethargic
+            } else {
+                Aggression::Aggressive
+            }
+        }
+        _ => default_aggression(kind),
+    }
+}
+
 /// Current disposition of this character toward the player party.
 #[derive(Debug, Clone, PartialEq, Component)]
 pub enum Aggression {

--- a/src/game.rs
+++ b/src/game.rs
@@ -171,7 +171,7 @@ impl GameSession {
         dialog.load_script(yaml).expect("load loop1.yaml");
 
         let mut rng = StdRng::seed_from_u64(rand::random::<u64>());
-        let zone = Zone::enter(ZoneKind::CommandDeck, 1, &mut rng);
+        let zone = Zone::enter(ZoneKind::CommandDeck, 1, 1, &mut rng);
 
         let mut exploration = ExplorationState {
             player_entity,
@@ -274,10 +274,11 @@ impl GameSession {
         .unwrap_or(CardinalDir::South);
 
         let depth = exploration.zone.depth;
+        let loop_number = self.loop_number;
         let origin = exploration.zone.kind;
         let player_entity = exploration.player_entity;
         exploration.travel = Some(TravelState::new(origin, destination, travel_dir));
-        exploration.zone = Zone::enter_hallway(depth, travel_dir, rng);
+        exploration.zone = Zone::enter_hallway(depth, loop_number, travel_dir, rng);
         exploration.npcs.clear();
         // Spawn 1 tile inward from the backtrack (entry) door.
         let spawn = spawn_pos_near_door(&exploration.zone, travel_dir.opposite());
@@ -306,7 +307,7 @@ impl GameSession {
         let loop_number = self.loop_number;
 
         if rng.r#gen::<f64>() < arrival_chance(loop_number) {
-            exploration.zone = Zone::enter(destination, depth, rng);
+            exploration.zone = Zone::enter(destination, depth, loop_number, rng);
             exploration.travel = None;
             exploration.npcs.clear();
             // Spawn 1 tile inward from the entry door (faces back toward origin).
@@ -319,7 +320,7 @@ impl GameSession {
             true
         } else {
             exploration.travel.as_mut().unwrap().hallways_traversed += 1;
-            exploration.zone = Zone::enter_hallway(depth, travel_dir, rng);
+            exploration.zone = Zone::enter_hallway(depth, loop_number, travel_dir, rng);
             exploration.npcs.clear();
             // Spawn 1 tile inward from the backtrack door.
             let spawn = spawn_pos_near_door(&exploration.zone, travel_dir.opposite());
@@ -376,8 +377,9 @@ impl GameSession {
         let origin = exploration.travel.as_ref().unwrap().origin;
         let travel_dir = exploration.travel.as_ref().unwrap().travel_dir;
         let depth = exploration.zone.depth;
+        let loop_number = self.loop_number;
         let player_entity = exploration.player_entity;
-        exploration.zone = Zone::enter(origin, depth, rng);
+        exploration.zone = Zone::enter(origin, depth, loop_number, rng);
         exploration.travel = None;
         exploration.npcs.clear();
         // Spawn 1 tile inward from the door that leads toward the destination.

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -81,9 +81,20 @@ impl CardinalDir {
     }
 }
 
-/// Probability that a combat encounter is generated when entering a zone.
-/// At 0.75, three out of four zone entries trigger a fight.
-pub const ENCOUNTER_CHANCE: f64 = 0.75;
+/// Probability of a combat encounter when entering a zone, scaled by loop number.
+///
+/// | Loop | Chance |
+/// |------|--------|
+/// |  1   | 40%    |
+/// |  2   | 55%    |
+/// |  3   | 70%    |
+/// |  4   | 85%    |
+/// |  5+  | 90%    |
+///
+/// Maximum clamped to 0.90.
+pub fn encounter_chance(loop_number: u32) -> f64 {
+    (0.25 + loop_number as f64 * 0.15).min(0.90)
+}
 
 /// Who, if anyone, has the initiative advantage at the start of an encounter.
 #[derive(Debug, Clone, PartialEq)]
@@ -107,6 +118,8 @@ pub struct Zone {
     pub kind: ZoneKind,
     pub connections: ZoneConnections,
     pub depth: u32,
+    /// Current loop number (1–5). Determines encounter probability and enemy pool.
+    pub loop_number: u32,
     /// Grid width (number of columns along the X axis).
     pub cols: u32,
     /// Grid height (number of rows along the Y axis).
@@ -123,29 +136,35 @@ pub struct Zone {
 impl Zone {
     /// Enter a zone, rolling for a random combat encounter first.
     ///
-    /// There is an [`ENCOUNTER_CHANCE`] probability that enemies are generated
-    /// using zone-appropriate terrain and enemy types. NPCs only phase-shift in
-    /// after the encounter is resolved (or immediately when there is none).
-    pub fn enter(kind: ZoneKind, depth: u32, rng: &mut impl Rng) -> Self {
-        let with_encounter = rng.r#gen::<f64>() < ENCOUNTER_CHANCE;
-        Self::build(kind, depth, with_encounter, None, rng)
+    /// Encounter probability scales with `loop_number` via [`encounter_chance`]:
+    /// higher loops mean more frequent and tougher fights. NPCs only phase-shift
+    /// in after the encounter is resolved (or immediately when there is none).
+    pub fn enter(kind: ZoneKind, depth: u32, loop_number: u32, rng: &mut impl Rng) -> Self {
+        let with_encounter = rng.r#gen::<f64>() < encounter_chance(loop_number);
+        Self::build(kind, depth, loop_number, with_encounter, None, rng)
     }
 
     /// Generate a zone with a guaranteed encounter, picking a random zone kind.
     /// Useful for testing and procedural content generation.
-    pub fn generate(depth: u32, rng: &mut impl Rng) -> Self {
+    pub fn generate(depth: u32, loop_number: u32, rng: &mut impl Rng) -> Self {
         let kind = random_zone_kind(rng);
-        Self::build(kind, depth, true, None, rng)
+        Self::build(kind, depth, loop_number, true, None, rng)
     }
 
     /// Enter an anonymous hallway zone used during travel between named zones.
     /// `travel_dir` is the direction toward the destination (exit door side).
     /// The opposite side gets a backtrack door leading back to the origin.
-    pub fn enter_hallway(depth: u32, travel_dir: CardinalDir, rng: &mut impl Rng) -> Self {
-        let with_encounter = rng.r#gen::<f64>() < ENCOUNTER_CHANCE;
+    pub fn enter_hallway(
+        depth: u32,
+        loop_number: u32,
+        travel_dir: CardinalDir,
+        rng: &mut impl Rng,
+    ) -> Self {
+        let with_encounter = rng.r#gen::<f64>() < encounter_chance(loop_number);
         Self::build(
             ZoneKind::Hallway,
             depth,
+            loop_number,
             with_encounter,
             Some(travel_dir),
             rng,
@@ -155,6 +174,7 @@ impl Zone {
     fn build(
         kind: ZoneKind,
         depth: u32,
+        loop_number: u32,
         with_encounter: bool,
         hallway_dir: Option<CardinalDir>,
         rng: &mut impl Rng,
@@ -210,6 +230,7 @@ impl Zone {
             kind,
             connections,
             depth,
+            loop_number,
             cols,
             rows,
             map,
@@ -226,12 +247,17 @@ impl Zone {
 
     /// Generate enemies for this zone's encounter. Returns an empty vec if there is no encounter.
     /// Call this when entering battle rather than storing enemies on the zone.
+    ///
+    /// Enemy types are filtered by `loop_number` via [`ZoneKind::combat_enemy_pool`], so only
+    /// faction members present and hostile at the current loop will appear. Aggression is
+    /// adjusted per loop using [`crate::character::loop_aggression`].
     pub fn generate_enemies(&self, rng: &mut impl Rng) -> Vec<(Character, Position)> {
+        use crate::character::loop_aggression;
         if !self.encounter {
             return Vec::new();
         }
         let enemy_level = self.depth.max(1);
-        let enemy_pool = self.kind.enemy_pool();
+        let enemy_pool = self.kind.combat_enemy_pool(self.loop_number);
         let enemy_count: usize = rng.gen_range(1..=4);
         let mut used: HashSet<(i32, i32)> = HashSet::new();
         let mut enemies = Vec::new();
@@ -240,10 +266,9 @@ impl Zone {
             let y = rng.gen_range(0..self.rows as i32);
             if self.map.get(x, y) == Tile::Open && used.insert((x, y)) {
                 let ek = enemy_pool[rng.gen_range(0..enemy_pool.len())].clone();
-                enemies.push((
-                    Character::new_character(ek, enemy_level),
-                    Position::new(x, y),
-                ));
+                let mut character = Character::new_character(ek, enemy_level);
+                character.aggression = loop_aggression(&character.kind, self.loop_number);
+                enemies.push((character, Position::new(x, y)));
             }
         }
         enemies
@@ -298,16 +323,41 @@ impl ZoneKind {
         }
     }
 
-    /// The set of enemy types that can spawn in encounters within this zone.
+    /// The full set of enemy types that may ever spawn in this zone (loop-independent).
+    ///
+    /// Use [`ZoneKind::combat_enemy_pool`] instead when generating actual encounters,
+    /// as it filters by loop number to match the narrative state of the station.
     pub fn enemy_pool(self) -> &'static [CharacterKind] {
         match self {
-            ZoneKind::ResearchWing => &[CharacterKind::MaintenanceDrone, CharacterKind::Scavenger],
-            ZoneKind::CommandDeck => &[CharacterKind::StationGuard, CharacterKind::SecurityUnit],
-            ZoneKind::MilitaryAnnex => &[CharacterKind::GunForHire, CharacterKind::ShockTrooper],
-            ZoneKind::SystemsCore => {
-                &[CharacterKind::MaintenanceDrone, CharacterKind::SecurityUnit]
-            }
-            ZoneKind::MedicalBay => &[CharacterKind::VoidSpitter, CharacterKind::StationGuard],
+            ZoneKind::ResearchWing => &[
+                CharacterKind::Zealot,
+                CharacterKind::Purifier,
+                CharacterKind::Preacher,
+                CharacterKind::MaintenanceDrone,
+                CharacterKind::Scavenger,
+            ],
+            ZoneKind::CommandDeck => &[
+                CharacterKind::Zealot,
+                CharacterKind::Purifier,
+                CharacterKind::Preacher,
+                CharacterKind::StationGuard,
+                CharacterKind::SecurityUnit,
+            ],
+            ZoneKind::MilitaryAnnex => &[
+                CharacterKind::GunForHire,
+                CharacterKind::ShockTrooper,
+                CharacterKind::Archon,
+            ],
+            ZoneKind::SystemsCore => &[
+                CharacterKind::MaintenanceDrone,
+                CharacterKind::SecurityUnit,
+                CharacterKind::CombatFrame,
+            ],
+            ZoneKind::MedicalBay => &[
+                CharacterKind::StationGuard,
+                CharacterKind::VoidSpitter,
+                CharacterKind::AbyssalBrute,
+            ],
             ZoneKind::DockingBay => &[
                 CharacterKind::Scavenger,
                 CharacterKind::VoidRaider,
@@ -329,7 +379,141 @@ impl ZoneKind {
                 CharacterKind::MaintenanceDrone,
                 CharacterKind::MoonCrawler,
                 CharacterKind::VoidRaider,
+                CharacterKind::Zealot,
+                CharacterKind::Purifier,
             ],
+        }
+    }
+
+    /// Loop-filtered set of enemies that actively fight when entering this zone.
+    ///
+    /// Based on world.md encounter tables and npcs.md faction behavior:
+    /// - Constancy members appear from loop 1 in Research Wing (the breach point) and spread
+    /// - Scavengers breach outer areas from loop 2+
+    /// - Automata Security Units go online from loop 2+; Maintenance Drones hostile from loop 3+
+    /// - Drifter Bosses establish themselves from loop 3+
+    /// - Shock Troopers deployed by Doss from loop 3+
+    /// - Abyssal Fauna surge from loop 2–3+; go Lethargic in loops 4–5
+    /// - Station Personnel flip to hostile in loops 3–5
+    pub fn combat_enemy_pool(self, loop_number: u32) -> Vec<CharacterKind> {
+        match self {
+            ZoneKind::ResearchWing => {
+                // Constancy breach site from loop 1; Drones hostile from loop 3+; Scavengers loop 2+
+                let mut pool = vec![CharacterKind::Zealot, CharacterKind::Purifier];
+                pool.push(CharacterKind::MaintenanceDrone);
+                if loop_number >= 2 {
+                    pool.push(CharacterKind::Scavenger);
+                    pool.push(CharacterKind::Preacher);
+                }
+                pool
+            }
+            ZoneKind::CommandDeck => {
+                // Constancy spread here; Security Units loop 2+; Guards hostile loops 4-5
+                let mut pool = vec![CharacterKind::Zealot];
+                if loop_number >= 2 {
+                    pool.push(CharacterKind::SecurityUnit);
+                    pool.push(CharacterKind::Purifier);
+                }
+                if loop_number >= 3 {
+                    pool.push(CharacterKind::Preacher);
+                }
+                if loop_number >= 4 {
+                    pool.push(CharacterKind::StationGuard);
+                }
+                pool
+            }
+            ZoneKind::MilitaryAnnex => {
+                // Gun-for-Hire always present; Shock Troopers from loop 3+; Archon loop 4+
+                let mut pool = vec![CharacterKind::GunForHire];
+                if loop_number >= 3 {
+                    pool.push(CharacterKind::ShockTrooper);
+                }
+                if loop_number >= 4 {
+                    pool.push(CharacterKind::Archon);
+                }
+                pool
+            }
+            ZoneKind::SystemsCore => {
+                // Maintenance Drones present all loops; Security Units loop 2+; CombatFrame loop 5
+                let mut pool = vec![CharacterKind::MaintenanceDrone];
+                if loop_number >= 2 {
+                    pool.push(CharacterKind::SecurityUnit);
+                }
+                if loop_number >= 5 {
+                    pool.push(CharacterKind::CombatFrame);
+                }
+                pool
+            }
+            ZoneKind::MedicalBay => {
+                // Guards hostile loop 3+; Void Spitters breach floor loop 4+; Brute loop 5 only
+                let mut pool = vec![];
+                if loop_number >= 3 {
+                    pool.push(CharacterKind::StationGuard);
+                }
+                if loop_number >= 4 {
+                    pool.push(CharacterKind::VoidSpitter);
+                }
+                if loop_number >= 5 {
+                    pool.push(CharacterKind::AbyssalBrute);
+                }
+                // Fallback for early loops: Scavengers who raided the medical supplies
+                if pool.is_empty() {
+                    pool.push(CharacterKind::Scavenger);
+                }
+                pool
+            }
+            ZoneKind::DockingBay => {
+                // Scavengers from loop 1; Raiders loop 2+; Boss loop 3+
+                let mut pool = vec![CharacterKind::Scavenger];
+                if loop_number >= 2 {
+                    pool.push(CharacterKind::VoidRaider);
+                }
+                if loop_number >= 3 {
+                    pool.push(CharacterKind::DrifterBoss);
+                }
+                pool
+            }
+            ZoneKind::StationExterior => {
+                // Moon Crawlers from loop 1; Raiders loop 2+; Abyssal Brutes loop 3+
+                let mut pool = vec![CharacterKind::MoonCrawler];
+                if loop_number >= 2 {
+                    pool.push(CharacterKind::VoidRaider);
+                }
+                if loop_number >= 3 {
+                    pool.push(CharacterKind::AbyssalBrute);
+                }
+                pool
+            }
+            ZoneKind::RelayArray => {
+                // Void Raiders camp here all loops; Boss establishes loop 2+
+                let mut pool = vec![CharacterKind::VoidRaider];
+                if loop_number >= 2 {
+                    pool.push(CharacterKind::DrifterBoss);
+                }
+                pool
+            }
+            ZoneKind::ExcavationSite => {
+                // Moon Crawlers all loops; Spitters and Brutes from loop 2+
+                let mut pool = vec![CharacterKind::MoonCrawler];
+                if loop_number >= 2 {
+                    pool.push(CharacterKind::VoidSpitter);
+                    pool.push(CharacterKind::AbyssalBrute);
+                }
+                pool
+            }
+            ZoneKind::Hallway => {
+                // Connecting corridors host any faction passing through
+                let mut pool = vec![CharacterKind::Scavenger, CharacterKind::MoonCrawler];
+                if loop_number >= 2 {
+                    pool.push(CharacterKind::VoidRaider);
+                    pool.push(CharacterKind::Zealot);
+                }
+                if loop_number >= 3 {
+                    pool.push(CharacterKind::MaintenanceDrone);
+                    pool.push(CharacterKind::Purifier);
+                }
+                pool
+            }
         }
     }
 }

--- a/tests/level_tests.rs
+++ b/tests/level_tests.rs
@@ -10,14 +10,14 @@ fn rng() -> StdRng {
 #[test]
 fn level_has_at_least_one_enemy() {
     let mut r = rng();
-    let zone = Zone::generate(1, &mut r);
+    let zone = Zone::generate(1, 1, &mut r);
     assert!(!zone.generate_enemies(&mut r).is_empty());
 }
 
 #[test]
 fn level_has_at_most_four_enemies() {
     let mut r = rng();
-    let zone = Zone::generate(1, &mut r);
+    let zone = Zone::generate(1, 1, &mut r);
     assert!(zone.generate_enemies(&mut r).len() <= 4);
 }
 
@@ -25,7 +25,7 @@ fn level_has_at_most_four_enemies() {
 fn enemy_level_matches_depth() {
     let depth = 5;
     let mut r = rng();
-    let zone = Zone::generate(depth, &mut r);
+    let zone = Zone::generate(depth, 1, &mut r);
     assert!(
         zone.generate_enemies(&mut r)
             .iter()
@@ -36,7 +36,7 @@ fn enemy_level_matches_depth() {
 #[test]
 fn depth_zero_clamps_enemy_level_to_one() {
     let mut r = rng();
-    let zone = Zone::generate(0, &mut r);
+    let zone = Zone::generate(0, 1, &mut r);
     assert!(
         zone.generate_enemies(&mut r)
             .iter()
@@ -47,7 +47,7 @@ fn depth_zero_clamps_enemy_level_to_one() {
 #[test]
 fn enemy_positions_are_within_grid() {
     let mut r = rng();
-    let zone = Zone::generate(1, &mut r);
+    let zone = Zone::generate(1, 1, &mut r);
     for (_, pos) in zone.generate_enemies(&mut r) {
         assert!(pos.x >= 0 && pos.x < zone.cols as i32);
         assert!(pos.y >= 0 && pos.y < zone.rows as i32);
@@ -57,7 +57,7 @@ fn enemy_positions_are_within_grid() {
 #[test]
 fn enemy_positions_are_unique() {
     let mut r = rng();
-    let zone = Zone::generate(1, &mut r);
+    let zone = Zone::generate(1, 1, &mut r);
     let enemies = zone.generate_enemies(&mut r);
     let positions: Vec<_> = enemies.iter().map(|(_, p)| (p.x, p.y)).collect();
     let unique: std::collections::HashSet<_> = positions.iter().collect();
@@ -79,7 +79,7 @@ fn surprise_states_all_occur_across_many_levels() {
     let mut saw_enemy_ambushed = false;
 
     for _ in 0..200 {
-        match Zone::generate(1, &mut rng).surprise {
+        match Zone::generate(1, 1, &mut rng).surprise {
             SurpriseState::Normal => saw_normal = true,
             SurpriseState::PartyAmbushed => saw_party_ambushed = true,
             SurpriseState::EnemyAmbushed => saw_enemy_ambushed = true,
@@ -94,11 +94,11 @@ fn surprise_states_all_occur_across_many_levels() {
 #[test]
 fn different_seeds_produce_different_levels() {
     let mut ra = StdRng::seed_from_u64(1);
-    let a = Zone::generate(3, &mut ra);
+    let a = Zone::generate(3, 1, &mut ra);
     let a_enemies = a.generate_enemies(&mut ra);
 
     let mut rb = StdRng::seed_from_u64(99);
-    let b = Zone::generate(3, &mut rb);
+    let b = Zone::generate(3, 1, &mut rb);
     let b_enemies = b.generate_enemies(&mut rb);
 
     let same = a_enemies.len() == b_enemies.len()
@@ -127,7 +127,7 @@ fn level_map_dimensions_match_cols_rows() {
 #[test]
 fn enemy_spawn_tiles_are_open() {
     let mut r = rng();
-    let zone = Zone::generate(1, &mut r);
+    let zone = Zone::generate(1, 1, &mut r);
     for (_, pos) in zone.generate_enemies(&mut r) {
         assert_eq!(
             zone.map.get(pos.x, pos.y),
@@ -145,7 +145,7 @@ fn all_zone_kind_variants_can_be_generated() {
     let mut saw = [false; 9];
 
     for _ in 0..500 {
-        let idx = match Zone::generate(1, &mut rng).kind {
+        let idx = match Zone::generate(1, 1, &mut rng).kind {
             ZoneKind::ResearchWing => 0,
             ZoneKind::CommandDeck => 1,
             ZoneKind::MilitaryAnnex => 2,

--- a/tests/zone_tests.rs
+++ b/tests/zone_tests.rs
@@ -1,4 +1,7 @@
-use carbonthrone::zone::{CardinalDir, ZoneKind, ZoneType, zone_connections};
+use carbonthrone::character::CharacterKind;
+use carbonthrone::zone::{
+    CardinalDir, Zone, ZoneKind, ZoneType, encounter_chance, zone_connections,
+};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 
@@ -127,21 +130,40 @@ fn exterior_zones_have_correct_type() {
     }
 }
 
+// ── Encounter chance scaling ──────────────────────────────────────────────────
+
+#[test]
+fn encounter_chance_increases_with_loop() {
+    assert!(encounter_chance(1) < encounter_chance(2));
+    assert!(encounter_chance(2) < encounter_chance(3));
+    assert!(encounter_chance(3) < encounter_chance(4));
+    assert!(encounter_chance(4) < encounter_chance(5));
+}
+
+#[test]
+fn encounter_chance_loop1_is_40_percent() {
+    assert!((encounter_chance(1) - 0.40).abs() < 1e-9);
+}
+
+#[test]
+fn encounter_chance_loop5_is_capped() {
+    assert!(encounter_chance(5) <= 0.90);
+    assert!(encounter_chance(100) <= 0.90);
+}
+
 // ── Zone encounter generation ─────────────────────────────────────────────────
 
 #[test]
 fn zone_enter_can_produce_encounter() {
-    use carbonthrone::zone::Zone;
     let mut r = rng();
-    let found = (0..50).any(|_| Zone::enter(ZoneKind::DockingBay, 1, &mut r).has_encounter());
+    let found = (0..50).any(|_| Zone::enter(ZoneKind::DockingBay, 1, 1, &mut r).has_encounter());
     assert!(found, "expected at least one encounter in 50 attempts");
 }
 
 #[test]
 fn zone_enter_can_skip_encounter() {
-    use carbonthrone::zone::Zone;
     let mut r = rng();
-    let found = (0..50).any(|_| !Zone::enter(ZoneKind::DockingBay, 1, &mut r).has_encounter());
+    let found = (0..50).any(|_| !Zone::enter(ZoneKind::DockingBay, 1, 1, &mut r).has_encounter());
     assert!(
         found,
         "expected at least one zone without encounter in 50 attempts"
@@ -150,10 +172,9 @@ fn zone_enter_can_skip_encounter() {
 
 #[test]
 fn zone_enter_encounter_has_enemies() {
-    use carbonthrone::zone::Zone;
     let mut r = rng();
     for _ in 0..50 {
-        let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut r);
+        let zone = Zone::enter(ZoneKind::DockingBay, 1, 1, &mut r);
         if zone.has_encounter() {
             assert!(
                 !zone.generate_enemies(&mut r).is_empty(),
@@ -167,11 +188,10 @@ fn zone_enter_encounter_has_enemies() {
 
 #[test]
 fn zone_enter_enemies_come_from_zone_pool() {
-    use carbonthrone::zone::Zone;
     let mut r = rng();
     let pool = ZoneKind::ResearchWing.enemy_pool();
     for _ in 0..50 {
-        let zone = Zone::enter(ZoneKind::ResearchWing, 1, &mut r);
+        let zone = Zone::enter(ZoneKind::ResearchWing, 1, 1, &mut r);
         if zone.has_encounter() {
             for (enemy, _) in zone.generate_enemies(&mut r) {
                 assert!(
@@ -186,25 +206,22 @@ fn zone_enter_enemies_come_from_zone_pool() {
 
 #[test]
 fn zone_kind_stored_on_zone() {
-    use carbonthrone::zone::Zone;
-    let zone = Zone::enter(ZoneKind::RelayArray, 3, &mut rng());
+    let zone = Zone::enter(ZoneKind::RelayArray, 3, 1, &mut rng());
     assert_eq!(zone.kind, ZoneKind::RelayArray);
 }
 
 #[test]
 fn zone_connections_stored_on_zone() {
-    use carbonthrone::zone::Zone;
-    let zone = Zone::enter(ZoneKind::RelayArray, 1, &mut rng());
+    let zone = Zone::enter(ZoneKind::RelayArray, 1, 1, &mut rng());
     assert_eq!(zone.connections.south, Some(ZoneKind::StationExterior));
 }
 
 #[test]
 fn enemy_level_matches_depth_in_zone() {
-    use carbonthrone::zone::Zone;
     let depth = 4;
     let mut r = rng();
     for _ in 0..50 {
-        let zone = Zone::enter(ZoneKind::MilitaryAnnex, depth, &mut r);
+        let zone = Zone::enter(ZoneKind::MilitaryAnnex, depth, 1, &mut r);
         if zone.has_encounter() {
             assert!(
                 zone.generate_enemies(&mut r)
@@ -219,7 +236,6 @@ fn enemy_level_matches_depth_in_zone() {
 
 #[test]
 fn all_zones_can_be_entered() {
-    use carbonthrone::zone::Zone;
     let all_zones = [
         ZoneKind::ResearchWing,
         ZoneKind::CommandDeck,
@@ -233,7 +249,7 @@ fn all_zones_can_be_entered() {
     ];
     let mut r = rng();
     for kind in all_zones {
-        let zone = Zone::enter(kind, 1, &mut r);
+        let zone = Zone::enter(kind, 1, 1, &mut r);
         assert_eq!(zone.kind, kind, "{:?} zone was not created correctly", kind);
     }
 }
@@ -242,10 +258,9 @@ fn all_zones_can_be_entered() {
 
 #[test]
 fn npcs_available_when_no_encounter() {
-    use carbonthrone::zone::Zone;
     let mut r = rng();
     for _ in 0..50 {
-        let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut r);
+        let zone = Zone::enter(ZoneKind::DockingBay, 1, 1, &mut r);
         if !zone.has_encounter() {
             assert!(
                 zone.npcs_available(false),
@@ -259,10 +274,9 @@ fn npcs_available_when_no_encounter() {
 
 #[test]
 fn npcs_not_available_during_active_encounter() {
-    use carbonthrone::zone::Zone;
     let mut r = rng();
     for _ in 0..50 {
-        let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut r);
+        let zone = Zone::enter(ZoneKind::DockingBay, 1, 1, &mut r);
         if zone.has_encounter() {
             assert!(
                 !zone.npcs_available(false),
@@ -276,10 +290,9 @@ fn npcs_not_available_during_active_encounter() {
 
 #[test]
 fn npcs_available_after_encounter_cleared() {
-    use carbonthrone::zone::Zone;
     let mut r = rng();
     for _ in 0..50 {
-        let zone = Zone::enter(ZoneKind::DockingBay, 1, &mut r);
+        let zone = Zone::enter(ZoneKind::DockingBay, 1, 1, &mut r);
         if zone.has_encounter() {
             assert!(
                 zone.npcs_available(true),
@@ -289,4 +302,221 @@ fn npcs_available_after_encounter_cleared() {
         }
     }
     panic!("could not find zone with encounter in 50 attempts");
+}
+
+// ── Loop-aware enemy pool ─────────────────────────────────────────────────────
+
+#[test]
+fn docking_bay_loop1_has_only_scavengers() {
+    let pool = ZoneKind::DockingBay.combat_enemy_pool(1);
+    assert!(pool.contains(&CharacterKind::Scavenger));
+    assert!(
+        !pool.contains(&CharacterKind::VoidRaider),
+        "Raiders arrive loop 2+"
+    );
+    assert!(
+        !pool.contains(&CharacterKind::DrifterBoss),
+        "Boss arrives loop 3+"
+    );
+}
+
+#[test]
+fn docking_bay_loop2_adds_void_raiders() {
+    let pool = ZoneKind::DockingBay.combat_enemy_pool(2);
+    assert!(pool.contains(&CharacterKind::Scavenger));
+    assert!(pool.contains(&CharacterKind::VoidRaider));
+    assert!(!pool.contains(&CharacterKind::DrifterBoss));
+}
+
+#[test]
+fn docking_bay_loop3_adds_drifter_boss() {
+    let pool = ZoneKind::DockingBay.combat_enemy_pool(3);
+    assert!(pool.contains(&CharacterKind::DrifterBoss));
+}
+
+#[test]
+fn excavation_site_loop1_only_moon_crawlers() {
+    let pool = ZoneKind::ExcavationSite.combat_enemy_pool(1);
+    assert!(pool.contains(&CharacterKind::MoonCrawler));
+    assert!(!pool.contains(&CharacterKind::VoidSpitter));
+    assert!(!pool.contains(&CharacterKind::AbyssalBrute));
+}
+
+#[test]
+fn excavation_site_loop2_adds_spitters_and_brutes() {
+    let pool = ZoneKind::ExcavationSite.combat_enemy_pool(2);
+    assert!(pool.contains(&CharacterKind::VoidSpitter));
+    assert!(pool.contains(&CharacterKind::AbyssalBrute));
+}
+
+#[test]
+fn medical_bay_loop1_fallback_scavengers() {
+    let pool = ZoneKind::MedicalBay.combat_enemy_pool(1);
+    assert!(
+        !pool.is_empty(),
+        "medical bay loop 1 pool must not be empty"
+    );
+    assert!(pool.contains(&CharacterKind::Scavenger));
+}
+
+#[test]
+fn medical_bay_loop4_adds_void_spitters() {
+    let pool = ZoneKind::MedicalBay.combat_enemy_pool(4);
+    assert!(pool.contains(&CharacterKind::VoidSpitter));
+}
+
+#[test]
+fn medical_bay_loop5_adds_abyssal_brute() {
+    let pool = ZoneKind::MedicalBay.combat_enemy_pool(5);
+    assert!(pool.contains(&CharacterKind::AbyssalBrute));
+}
+
+#[test]
+fn military_annex_loop1_has_gun_for_hire() {
+    let pool = ZoneKind::MilitaryAnnex.combat_enemy_pool(1);
+    assert!(pool.contains(&CharacterKind::GunForHire));
+    assert!(!pool.contains(&CharacterKind::ShockTrooper));
+}
+
+#[test]
+fn military_annex_loop3_adds_shock_troopers() {
+    let pool = ZoneKind::MilitaryAnnex.combat_enemy_pool(3);
+    assert!(pool.contains(&CharacterKind::ShockTrooper));
+}
+
+#[test]
+fn research_wing_loop1_has_constancy() {
+    let pool = ZoneKind::ResearchWing.combat_enemy_pool(1);
+    assert!(pool.contains(&CharacterKind::Zealot));
+    assert!(pool.contains(&CharacterKind::Purifier));
+    assert!(
+        !pool.contains(&CharacterKind::Preacher),
+        "Preachers arrive loop 2+"
+    );
+}
+
+#[test]
+fn research_wing_loop2_adds_scavengers_and_preachers() {
+    let pool = ZoneKind::ResearchWing.combat_enemy_pool(2);
+    assert!(pool.contains(&CharacterKind::Scavenger));
+    assert!(pool.contains(&CharacterKind::Preacher));
+}
+
+#[test]
+fn all_combat_pools_are_nonempty_for_all_loops() {
+    let all_zones = [
+        ZoneKind::ResearchWing,
+        ZoneKind::CommandDeck,
+        ZoneKind::MilitaryAnnex,
+        ZoneKind::SystemsCore,
+        ZoneKind::MedicalBay,
+        ZoneKind::DockingBay,
+        ZoneKind::StationExterior,
+        ZoneKind::RelayArray,
+        ZoneKind::ExcavationSite,
+        ZoneKind::Hallway,
+    ];
+    for loop_number in 1..=5 {
+        for zone in all_zones {
+            let pool = zone.combat_enemy_pool(loop_number);
+            assert!(
+                !pool.is_empty(),
+                "{:?} loop {} has empty combat pool",
+                zone,
+                loop_number
+            );
+        }
+    }
+}
+
+// ── Loop-aware aggression ─────────────────────────────────────────────────────
+
+#[test]
+fn loop_aggression_maintenance_drone_neutral_early_hostile_late() {
+    use carbonthrone::character::{Aggression, loop_aggression};
+    assert_eq!(
+        loop_aggression(&CharacterKind::MaintenanceDrone, 1),
+        Aggression::Neutral
+    );
+    assert_eq!(
+        loop_aggression(&CharacterKind::MaintenanceDrone, 2),
+        Aggression::Neutral
+    );
+    assert_eq!(
+        loop_aggression(&CharacterKind::MaintenanceDrone, 3),
+        Aggression::Aggressive
+    );
+}
+
+#[test]
+fn loop_aggression_station_guard_flips_over_loops() {
+    use carbonthrone::character::{Aggression, loop_aggression};
+    assert_eq!(
+        loop_aggression(&CharacterKind::StationGuard, 1),
+        Aggression::Friendly
+    );
+    assert_eq!(
+        loop_aggression(&CharacterKind::StationGuard, 3),
+        Aggression::Neutral
+    );
+    assert_eq!(
+        loop_aggression(&CharacterKind::StationGuard, 4),
+        Aggression::Aggressive
+    );
+}
+
+#[test]
+fn loop_aggression_abyssal_fauna_lethargic_in_late_loops() {
+    use carbonthrone::character::{Aggression, loop_aggression};
+    assert_eq!(
+        loop_aggression(&CharacterKind::MoonCrawler, 3),
+        Aggression::Aggressive
+    );
+    assert_eq!(
+        loop_aggression(&CharacterKind::MoonCrawler, 4),
+        Aggression::Lethargic
+    );
+    assert_eq!(
+        loop_aggression(&CharacterKind::AbyssalBrute, 5),
+        Aggression::Lethargic
+    );
+}
+
+#[test]
+fn generated_enemies_have_loop_appropriate_aggression() {
+    use carbonthrone::character::Aggression;
+    let mut r = rng();
+    // In loop 3, Maintenance Drones in SystemsCore should be Aggressive
+    for _ in 0..100 {
+        let zone = Zone::enter(ZoneKind::SystemsCore, 3, 3, &mut r);
+        if zone.has_encounter() {
+            for (enemy, _) in zone.generate_enemies(&mut r) {
+                if enemy.kind == CharacterKind::MaintenanceDrone {
+                    assert_eq!(
+                        enemy.aggression,
+                        Aggression::Aggressive,
+                        "Drones should be Aggressive in loop 3"
+                    );
+                }
+            }
+            return;
+        }
+    }
+}
+
+#[test]
+fn higher_loop_produces_more_encounters_on_average() {
+    let mut r = rng();
+    let loop1_encounters: u32 = (0..200)
+        .map(|_| Zone::enter(ZoneKind::StationExterior, 1, 1, &mut r).has_encounter() as u32)
+        .sum();
+    let loop5_encounters: u32 = (0..200)
+        .map(|_| Zone::enter(ZoneKind::StationExterior, 1, 5, &mut r).has_encounter() as u32)
+        .sum();
+    assert!(
+        loop5_encounters > loop1_encounters,
+        "loop 5 ({} encounters) should have more than loop 1 ({} encounters) over 200 tries",
+        loop5_encounters,
+        loop1_encounters
+    );
 }


### PR DESCRIPTION
Implements the random encounter system from #16.

Encounter probability now scales with loop number (40% loop 1 → 90% loop 5+). Enemy pools are filtered per zone and loop, matching world.md encounter tables and npcs.md faction lore. Aggression evolves over loops (Drones go hostile loop 3+, Station Guards flip, Abyssal Fauna go Lethargic in loops 4-5).

Closes #16

Generated with [Claude Code](https://claude.ai/code)