### PR TITLE
feat: scripted encounter system

### DIFF
--- a/src/combat.rs
+++ b/src/combat.rs
@@ -10,6 +10,7 @@ use crate::{
     health::Health,
     player_input::{PlayerActionChoice, available_player_actions},
     position::Position,
+    scripted_encounter::{ScriptedAlly, ScriptedFirstAction},
     stats::Stats,
     terrain::{CoverLevel, Direction, LevelMap},
     turn::{Action, apply_action},
@@ -202,6 +203,18 @@ impl BattleStep {
     /// The next entity waiting to act this turn, if any.
     pub fn next_actor(&self) -> Option<Entity> {
         self.actor_queue.front().copied()
+    }
+
+    /// Returns `true` when the next queued player actor is a scripted
+    /// (AI-controlled) ally rather than a true player character.
+    ///
+    /// Callers that drive combat interactively should auto-advance scripted
+    /// allies by calling [`Self::step`] instead of waiting for player input.
+    pub fn current_actor_is_scripted_ally(&self, world: &World) -> bool {
+        self.actor_queue
+            .front()
+            .map(|&e| world.get::<ScriptedAlly>(e).is_some())
+            .unwrap_or(false)
     }
 
     /// Advance one actor's full turn (all AP spent). Returns what happened.
@@ -422,11 +435,17 @@ fn is_offensive_ability(effect: &AbilityEffect) -> bool {
     )
 }
 
-/// AI entry point: seek cover first, then choose an ability.
+/// AI entry point: execute a scripted first action if present, then seek cover
+/// and choose an ability via normal tactics.
 fn choose_action(world: &mut World, actor: Entity, turn: Turn) -> Option<Action> {
     let ap = world.get::<ActionPoints>(actor)?.current;
     if ap == 0 {
         return Some(Action::Pass);
+    }
+
+    // Check for a scripted first action before falling back to tactical AI.
+    if let Some(scripted) = choose_scripted_action(world, actor, turn) {
+        return Some(scripted);
     }
 
     let min_cost = min_offensive_ap_cost(world, actor);
@@ -442,6 +461,70 @@ fn choose_action(world: &mut World, actor: Entity, turn: Turn) -> Option<Action>
     }
 
     Some(Action::Pass)
+}
+
+/// If the actor has an unexecuted [`ScriptedFirstAction`], attempt to use that
+/// ability and mark it as executed.  Returns `None` when the component is
+/// absent, already executed, the ability is unknown, or no valid target exists.
+fn choose_scripted_action(world: &mut World, actor: Entity, turn: Turn) -> Option<Action> {
+    // Peek at the scripted component without holding a reference.
+    let ability_name: &'static str = {
+        let sfa = world.get::<ScriptedFirstAction>(actor)?;
+        if sfa.executed {
+            return None;
+        }
+        sfa.ability_name
+    };
+
+    let (kind, level) = {
+        let c = world.get::<Character>(actor)?;
+        (c.kind.clone(), c.level)
+    };
+
+    // Locate the ability by name in this character's ability table.
+    let ability = character_abilities(&kind)
+        .into_iter()
+        .find(|a| a.name == ability_name && a.level_required <= level)?;
+
+    let actor_pos = world.get::<Position>(actor).copied()?;
+
+    // Resolve the target based on ability kind.
+    let target: Option<Entity> = match ability.kind {
+        AbilityKind::Melee => {
+            // Collect adjacent enemy positions (borrow dropped before mutable access).
+            let target_positions: Vec<(Entity, i32, i32)> = {
+                let mut q = world.query::<(Entity, &Character, &Health, &Position)>();
+                q.iter(world)
+                    .filter(|(_, c, h, _)| match turn {
+                        Turn::Player => {
+                            !c.kind.is_player()
+                                && c.aggression != Aggression::Friendly
+                                && h.is_alive()
+                        }
+                        Turn::Enemy => c.kind.is_player() && h.is_alive(),
+                    })
+                    .map(|(e, _, _, pos)| (e, pos.x, pos.y))
+                    .collect()
+            };
+            best_adjacent_target(&target_positions, actor_pos)
+        }
+        AbilityKind::Ranged => best_attack_target(world, actor, turn),
+        // Utility abilities are self-targeted (target = None handled by apply_ability).
+        AbilityKind::Utility => None,
+    };
+
+    // For targeted abilities that need a target, skip if none available.
+    if matches!(ability.kind, AbilityKind::Melee | AbilityKind::Ranged) && target.is_none() {
+        // Can't execute yet — don't mark as executed so the normal AI can act.
+        return None;
+    }
+
+    // Mark the scripted action as executed before returning.
+    if let Some(mut sfa) = world.get_mut::<ScriptedFirstAction>(actor) {
+        sfa.executed = true;
+    }
+
+    Some(Action::UseAbility { ability, target })
 }
 
 /// Chooses an offensive ability and target for the actor.

--- a/src/game.rs
+++ b/src/game.rs
@@ -10,6 +10,9 @@ use crate::experience::Experience;
 use crate::health::Health;
 use crate::position::Position;
 use crate::save::SaveData;
+use crate::scripted_encounter::{
+    ScriptedAlly, ScriptedEncounter, ScriptedFirstAction, scripted_encounter_for,
+};
 use crate::terrain::{BattleRng, LevelMap};
 use crate::travel::TravelState;
 use crate::travel::arrival_chance;
@@ -215,6 +218,10 @@ impl GameSession {
     }
 
     /// Transition from exploration into a fresh battle.
+    ///
+    /// If a [`ScriptedEncounter`] is registered for the current zone and loop
+    /// number, it overrides random enemy generation: enemies spawn at fixed
+    /// positions and temporary allies are spawned alongside the player.
     pub fn transition_to_battle(&mut self) {
         let GamePhase::Exploration(_) = &self.phase else {
             return;
@@ -224,7 +231,8 @@ impl GameSession {
         else {
             unreachable!()
         };
-        setup_battle(&mut self.world, &exploration.zone);
+        let script = scripted_encounter_for(exploration.zone.kind, self.loop_number);
+        setup_battle(&mut self.world, &exploration.zone, script.as_ref());
         self.battle = Some(BattleStep::new(&mut self.world));
         self.last_event = None;
         self.phase = GamePhase::Battle(exploration);
@@ -256,6 +264,15 @@ impl GameSession {
                 .collect()
         };
         for e in enemies {
+            self.world.despawn(e);
+        }
+        // Despawn temporary scripted allies (player-kind characters added just
+        // for this encounter — identified by the ScriptedAlly marker).
+        let scripted_allies: Vec<Entity> = {
+            let mut q = self.world.query::<(Entity, &ScriptedAlly)>();
+            q.iter(&self.world).map(|(e, _)| e).collect()
+        };
+        for e in scripted_allies {
             self.world.despawn(e);
         }
         self.world.remove_resource::<LevelMap>();
@@ -323,8 +340,13 @@ impl GameSession {
         if rng.r#gen::<f64>() < arrival_chance(loop_number) {
             exploration.zone = Zone::enter(destination, depth, loop_number, rng);
             exploration.travel = None;
-            exploration.npcs =
-                zone_npcs(exploration.zone.kind, exploration.zone.cols, exploration.zone.rows, loop_number, exploration.dialog.flags());
+            exploration.npcs = zone_npcs(
+                exploration.zone.kind,
+                exploration.zone.cols,
+                exploration.zone.rows,
+                loop_number,
+                exploration.dialog.flags(),
+            );
             sync_companion(&mut exploration.dialog);
             // Spawn 1 tile inward from the entry door (faces back toward origin).
             let spawn = spawn_pos_near_door(&exploration.zone, travel_dir.opposite());
@@ -397,8 +419,13 @@ impl GameSession {
         let player_entity = exploration.player_entity;
         exploration.zone = Zone::enter(origin, depth, loop_number, rng);
         exploration.travel = None;
-        exploration.npcs =
-            zone_npcs(exploration.zone.kind, exploration.zone.cols, exploration.zone.rows, loop_number, exploration.dialog.flags());
+        exploration.npcs = zone_npcs(
+            exploration.zone.kind,
+            exploration.zone.cols,
+            exploration.zone.rows,
+            loop_number,
+            exploration.dialog.flags(),
+        );
         sync_companion(&mut exploration.dialog);
         // Spawn 1 tile inward from the door that leads toward the destination.
         let spawn = spawn_pos_near_door(&exploration.zone, travel_dir);
@@ -441,8 +468,13 @@ impl GameSession {
         let player_entity = exploration.player_entity;
         exploration.zone = Zone::enter(ZoneKind::ResearchWing, 1, loop_number, rng);
         exploration.travel = None;
-        exploration.npcs =
-            zone_npcs(exploration.zone.kind, exploration.zone.cols, exploration.zone.rows, loop_number, exploration.dialog.flags());
+        exploration.npcs = zone_npcs(
+            exploration.zone.kind,
+            exploration.zone.cols,
+            exploration.zone.rows,
+            loop_number,
+            exploration.dialog.flags(),
+        );
         sync_companion(&mut exploration.dialog);
         *self
             .world
@@ -569,12 +601,58 @@ pub fn setup_exploration(world: &mut World, party: &[Character]) -> Entity {
 
 /// Adds enemies and battle resources to the world. Party is already present from
 /// `setup_exploration`.
-pub fn setup_battle(world: &mut World, zone: &Zone) {
+///
+/// When `script` is `Some`, enemy positions are taken from the scripted
+/// encounter definition instead of being generated randomly.  Scripted allies
+/// are spawned with the [`ScriptedAlly`] marker component so they are
+/// despawned at the end of combat.
+pub fn setup_battle(world: &mut World, zone: &Zone, script: Option<&ScriptedEncounter>) {
     let mut rng = StdRng::seed_from_u64(rand::random::<u64>());
-    for (character, pos) in zone.generate_enemies(&mut rng) {
-        let stats = character.stats.clone();
-        let hp = character.current_hp;
-        world.spawn((character, stats, Health::new(hp), ActionPoints::new(4), pos));
+
+    // Spawn enemies — either from the script or generated randomly.
+    if let Some(s) = script {
+        for placement in &s.enemies {
+            let (character, pos) = placement.to_character_and_pos(zone.cols, zone.rows);
+            let stats = character.stats.clone();
+            let hp = character.current_hp;
+            let mut entity_cmd =
+                world.spawn((character, stats, Health::new(hp), ActionPoints::new(4), pos));
+            if let Some(ability_name) = placement.first_ability {
+                entity_cmd.insert(ScriptedFirstAction {
+                    ability_name,
+                    executed: false,
+                });
+            }
+        }
+    } else {
+        for (character, pos) in zone.generate_enemies(&mut rng) {
+            let stats = character.stats.clone();
+            let hp = character.current_hp;
+            world.spawn((character, stats, Health::new(hp), ActionPoints::new(4), pos));
+        }
+    }
+
+    // Spawn scripted allies (temporary, fight on the player's side).
+    if let Some(s) = script {
+        for placement in &s.allies {
+            let (character, pos) = placement.to_character_and_pos(zone.cols, zone.rows);
+            let stats = character.stats.clone();
+            let hp = character.current_hp;
+            let mut entity_cmd = world.spawn((
+                character,
+                stats,
+                Health::new(hp),
+                ActionPoints::new(4),
+                pos,
+                ScriptedAlly,
+            ));
+            if let Some(ability_name) = placement.first_ability {
+                entity_cmd.insert(ScriptedFirstAction {
+                    ability_name,
+                    executed: false,
+                });
+            }
+        }
     }
 
     let battle_rng = StdRng::seed_from_u64(rand::random::<u64>());
@@ -656,4 +734,3 @@ pub fn sync_companion(dialog: &mut DialogEngine) {
         dialog.set_companion("kaleo");
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod health;
 pub mod player_input;
 pub mod position;
 pub mod save;
+pub mod scripted_encounter;
 pub mod stats;
 pub mod terrain;
 pub mod travel;

--- a/src/scripted_encounter.rs
+++ b/src/scripted_encounter.rs
@@ -1,0 +1,240 @@
+//! Scripted combat encounters.
+//!
+//! A [`ScriptedEncounter`] defines fixed combatant placements for a specific
+//! zone + loop combination, overriding the zone's random enemy generation.
+//! Use [`scripted_encounter_for`] to look up the encounter definition.
+//!
+//! Allies defined in a scripted encounter are spawned as temporary combatants
+//! that fight alongside the player and are despawned at combat end just like
+//! enemies.  They are tagged with the [`ScriptedAlly`] Bevy component so the
+//! rest of the engine can distinguish them from persistent party members.
+//!
+//! The [`ScriptedFirstAction`] Bevy component, when attached to an entity,
+//! causes the AI to attempt the named ability on its first combat turn before
+//! falling back to normal tactical reasoning.
+
+use bevy::prelude::Component;
+
+use crate::character::{Aggression, Character, CharacterKind};
+use crate::position::Position;
+use crate::zone::ZoneKind;
+
+// ── Spawn location ────────────────────────────────────────────────────────────
+
+/// Where on the map to place a scripted combatant.
+///
+/// Positions are resolved at encounter setup time once the map dimensions are
+/// known, so they remain valid across randomly-sized zone layouts.
+#[derive(Debug, Clone)]
+pub enum SpawnLocation {
+    /// Near the centre of the north (top) edge — low y values.
+    NorthWall,
+    /// Near the centre of the south (bottom) edge — high y values.
+    SouthWall,
+    /// Near the centre of the east (right) edge — high x values.
+    EastWall,
+    /// Near the centre of the west (left) edge — low x values.
+    WestWall,
+    /// Geometric centre of the map.
+    Center,
+    /// Arbitrary position expressed as fractions of (cols, rows), clamped to
+    /// valid bounds.  `(0.0, 0.0)` is the north-west corner; `(1.0, 1.0)` the
+    /// south-east corner.
+    Fraction(f32, f32),
+}
+
+impl SpawnLocation {
+    /// Convert to an absolute grid coordinate given the map dimensions.
+    pub fn to_grid(&self, cols: u32, rows: u32) -> (i32, i32) {
+        let c = cols as i32;
+        let r = rows as i32;
+        match self {
+            SpawnLocation::NorthWall => (c / 2, 1.max(0)),
+            SpawnLocation::SouthWall => (c / 2, (r - 2).max(0)),
+            SpawnLocation::EastWall => ((c - 2).max(0), r / 2),
+            SpawnLocation::WestWall => (1.max(0), r / 2),
+            SpawnLocation::Center => (c / 2, r / 2),
+            SpawnLocation::Fraction(fx, fy) => (
+                ((cols as f32 * fx) as i32).clamp(0, c - 1),
+                ((rows as f32 * fy) as i32).clamp(0, r - 1),
+            ),
+        }
+    }
+}
+
+// ── Placement spec ────────────────────────────────────────────────────────────
+
+/// Fixed placement for one combatant within a scripted encounter.
+#[derive(Debug, Clone)]
+pub struct CombatantPlacement {
+    pub kind: CharacterKind,
+    pub level: u32,
+    pub location: SpawnLocation,
+    /// Override the default aggression for this kind; `None` keeps the default.
+    pub aggression: Option<Aggression>,
+    /// If `Some`, the AI will attempt the ability with this name on the
+    /// entity's very first combat turn before falling back to normal tactics.
+    pub first_ability: Option<&'static str>,
+}
+
+impl CombatantPlacement {
+    /// Construct a [`Character`] and [`Position`] from this placement spec.
+    pub fn to_character_and_pos(&self, cols: u32, rows: u32) -> (Character, Position) {
+        let mut ch = Character::new_character(self.kind.clone(), self.level);
+        if let Some(agg) = self.aggression.clone() {
+            ch.aggression = agg;
+        }
+        let (x, y) = self.location.to_grid(cols, rows);
+        (ch, Position::new(x, y))
+    }
+}
+
+// ── ScriptedEncounter ─────────────────────────────────────────────────────────
+
+/// A fully scripted combat encounter that overrides random enemy generation.
+///
+/// Enemies are placed at fixed positions rather than spawned randomly.
+/// Allies fight alongside the player for the duration of combat and are
+/// despawned together with enemies when combat ends.
+#[derive(Debug, Clone)]
+pub struct ScriptedEncounter {
+    /// Unique identifier, used in tests and future save/load support.
+    pub id: &'static str,
+    /// Enemy combatants placed at fixed positions.
+    pub enemies: Vec<CombatantPlacement>,
+    /// Temporary ally combatants that fight on the player's side.
+    pub allies: Vec<CombatantPlacement>,
+}
+
+// ── Bevy components ───────────────────────────────────────────────────────────
+
+/// Marker component for temporary scripted allies.
+///
+/// Entities tagged with this are spawned for a single scripted encounter and
+/// despawned when combat ends, even if their `CharacterKind::is_player()` is
+/// `true`.
+#[derive(Debug, Clone, Component)]
+pub struct ScriptedAlly;
+
+/// Bevy ECS component: instructs the AI to use the named ability on this
+/// entity's first combat turn before switching to normal tactical AI.
+///
+/// Once the scripted turn has been taken, `executed` is set to `true` and
+/// subsequent turns use normal AI logic.
+#[derive(Debug, Clone, Component)]
+pub struct ScriptedFirstAction {
+    /// Name of the ability to use (matched against [`crate::ability::Ability::name`]).
+    pub ability_name: &'static str,
+    /// Set to `true` once the scripted action has been executed.
+    pub executed: bool,
+}
+
+// ── Encounter registry ────────────────────────────────────────────────────────
+
+/// Return the scripted encounter for the given zone and loop number, or `None`
+/// when the encounter for this zone should be generated randomly.
+pub fn scripted_encounter_for(zone: ZoneKind, loop_number: u32) -> Option<ScriptedEncounter> {
+    match (zone, loop_number) {
+        // Loop 1, ResearchWing: tutorial opening fight.
+        // Constancy Zealots and a Purifier breach from the north wall;
+        // Orin and Doss fight alongside the player at the south end.
+        (ZoneKind::ResearchWing, 1) => Some(tutorial_opening()),
+
+        // Loop 4+, MilitaryAnnex: the Archon appears with a ShockTrooper
+        // bodyguard.  Pre-combat dialog is driven by the YAML scene
+        // `loop4_archon_precombat`.
+        (ZoneKind::MilitaryAnnex, 4..) => Some(archon_encounter()),
+
+        _ => None,
+    }
+}
+
+// ── Concrete encounter definitions ────────────────────────────────────────────
+
+/// Loop 1 tutorial — Constancy breach in Room 7-C (ResearchWing).
+///
+/// From `docs/loops/loop1.md`:
+/// - Orin drops a stabilization field (heals) while calling positions
+/// - Doss tanks a charge with a heavy strike
+/// - Kaleo is in the terminals — not spawned physically in this fight
+/// - Zealots and a Purifier breach from the opposite side of the room (north)
+fn tutorial_opening() -> ScriptedEncounter {
+    ScriptedEncounter {
+        id: "tutorial_opening",
+        enemies: vec![
+            // Breach point: north wall, left-centre
+            CombatantPlacement {
+                kind: CharacterKind::Zealot,
+                level: 1,
+                location: SpawnLocation::Fraction(0.3, 0.08),
+                aggression: None,
+                first_ability: Some("Zealot Strike"),
+            },
+            // Breach point: north wall, right-centre
+            CombatantPlacement {
+                kind: CharacterKind::Zealot,
+                level: 1,
+                location: SpawnLocation::Fraction(0.7, 0.08),
+                aggression: None,
+                first_ability: None,
+            },
+            // Ranged support from the breach doorway
+            CombatantPlacement {
+                kind: CharacterKind::Purifier,
+                level: 1,
+                location: SpawnLocation::Fraction(0.5, 0.05),
+                aggression: None,
+                first_ability: Some("Purifying Round"),
+            },
+        ],
+        allies: vec![
+            // Orin: shield projector running, calls positions — heals first
+            CombatantPlacement {
+                kind: CharacterKind::Orin,
+                level: 1,
+                location: SpawnLocation::Fraction(0.35, 0.85),
+                aggression: Some(Aggression::Friendly),
+                first_ability: Some("Heal"),
+            },
+            // Doss: back to a pillar, kinetic rifle up — power strike first
+            CombatantPlacement {
+                kind: CharacterKind::Doss,
+                level: 1,
+                location: SpawnLocation::Fraction(0.65, 0.85),
+                aggression: Some(Aggression::Friendly),
+                first_ability: Some("Power Strike"),
+            },
+        ],
+    }
+}
+
+/// Loop 4+ MilitaryAnnex — Archon encounter.
+///
+/// From `docs/loops/loop4.md`: The Archon pauses before the fight and
+/// acknowledges the player across loops.  Pre-combat dialog is handled by the
+/// YAML scene `loop4_archon_precombat`.  The Archon spawns at the far wall
+/// with a ShockTrooper bodyguard on the right flank.
+fn archon_encounter() -> ScriptedEncounter {
+    ScriptedEncounter {
+        id: "archon_encounter",
+        enemies: vec![
+            // Archon at the north wall, facing the player's entry point
+            CombatantPlacement {
+                kind: CharacterKind::Archon,
+                level: 4,
+                location: SpawnLocation::NorthWall,
+                aggression: None,
+                first_ability: Some("Temporal Suppression"),
+            },
+            // ShockTrooper flanking right
+            CombatantPlacement {
+                kind: CharacterKind::ShockTrooper,
+                level: 3,
+                location: SpawnLocation::Fraction(0.8, 0.2),
+                aggression: None,
+                first_ability: None,
+            },
+        ],
+        allies: vec![],
+    }
+}

--- a/tests/scripted_encounter_tests.rs
+++ b/tests/scripted_encounter_tests.rs
@@ -1,0 +1,440 @@
+use bevy::prelude::*;
+use carbonthrone::{
+    action_points::ActionPoints,
+    character::{Character, CharacterKind},
+    combat::{BattleOutcome, BattleStep, simulate_battle},
+    health::Health,
+    position::Position,
+    scripted_encounter::{
+        CombatantPlacement, ScriptedAlly, ScriptedEncounter, ScriptedFirstAction, SpawnLocation,
+        scripted_encounter_for,
+    },
+    stats::Stats,
+    zone::ZoneKind,
+};
+
+// ── SpawnLocation ─────────────────────────────────────────────────────────────
+
+#[test]
+fn spawn_location_north_wall_is_near_top() {
+    let (x, y) = SpawnLocation::NorthWall.to_grid(12, 10);
+    assert_eq!(x, 6); // cols / 2
+    assert!(y <= 2, "north wall should be near top (y={y})");
+}
+
+#[test]
+fn spawn_location_south_wall_is_near_bottom() {
+    let (x, y) = SpawnLocation::SouthWall.to_grid(12, 10);
+    assert_eq!(x, 6);
+    assert!(y >= 7, "south wall should be near bottom (y={y})");
+}
+
+#[test]
+fn spawn_location_east_wall_is_near_right() {
+    let (x, y) = SpawnLocation::EastWall.to_grid(12, 10);
+    assert!(x >= 9, "east wall should be near right (x={x})");
+    assert_eq!(y, 5); // rows / 2
+}
+
+#[test]
+fn spawn_location_west_wall_is_near_left() {
+    let (x, y) = SpawnLocation::WestWall.to_grid(12, 10);
+    assert!(x <= 2, "west wall should be near left (x={x})");
+    assert_eq!(y, 5);
+}
+
+#[test]
+fn spawn_location_center_is_middle() {
+    let (x, y) = SpawnLocation::Center.to_grid(12, 10);
+    assert_eq!(x, 6);
+    assert_eq!(y, 5);
+}
+
+#[test]
+fn spawn_location_fraction_maps_correctly() {
+    let (x, y) = SpawnLocation::Fraction(0.5, 0.1).to_grid(10, 10);
+    assert_eq!(x, 5);
+    assert_eq!(y, 1);
+}
+
+#[test]
+fn spawn_location_fraction_clamps_to_bounds() {
+    // Values beyond 1.0 should clamp to valid grid indices.
+    let (x, y) = SpawnLocation::Fraction(2.0, 2.0).to_grid(8, 8);
+    assert!(x < 8, "x should be clamped (got {x})");
+    assert!(y < 8, "y should be clamped (got {y})");
+}
+
+// ── CombatantPlacement ────────────────────────────────────────────────────────
+
+#[test]
+fn combatant_placement_creates_character_at_location() {
+    let placement = CombatantPlacement {
+        kind: CharacterKind::Zealot,
+        level: 1,
+        location: SpawnLocation::NorthWall,
+        aggression: None,
+        first_ability: None,
+    };
+    let (ch, pos) = placement.to_character_and_pos(12, 10);
+    assert_eq!(ch.kind, CharacterKind::Zealot);
+    assert_eq!(ch.level, 1);
+    assert_eq!(pos.x, 6); // cols / 2
+    assert!(pos.y <= 2, "position should be near north wall");
+}
+
+#[test]
+fn combatant_placement_overrides_aggression() {
+    use carbonthrone::character::Aggression;
+    let placement = CombatantPlacement {
+        kind: CharacterKind::Zealot,
+        level: 1,
+        location: SpawnLocation::Center,
+        aggression: Some(Aggression::Friendly),
+        first_ability: None,
+    };
+    let (ch, _) = placement.to_character_and_pos(10, 10);
+    assert_eq!(ch.aggression, Aggression::Friendly);
+}
+
+// ── scripted_encounter_for ────────────────────────────────────────────────────
+
+#[test]
+fn tutorial_encounter_returned_for_research_wing_loop1() {
+    let enc = scripted_encounter_for(ZoneKind::ResearchWing, 1);
+    assert!(enc.is_some(), "should have a scripted encounter");
+    let enc = enc.unwrap();
+    assert_eq!(enc.id, "tutorial_opening");
+}
+
+#[test]
+fn tutorial_encounter_has_three_enemies_and_two_allies() {
+    let enc = scripted_encounter_for(ZoneKind::ResearchWing, 1).unwrap();
+    assert_eq!(enc.enemies.len(), 3, "tutorial should have 3 enemies");
+    assert_eq!(enc.allies.len(), 2, "tutorial should have 2 allies");
+}
+
+#[test]
+fn tutorial_enemies_are_constancy_faction() {
+    let enc = scripted_encounter_for(ZoneKind::ResearchWing, 1).unwrap();
+    let kinds: Vec<&CharacterKind> = enc.enemies.iter().map(|p| &p.kind).collect();
+    assert!(
+        kinds.contains(&&CharacterKind::Zealot),
+        "tutorial should have Zealots"
+    );
+    assert!(
+        kinds.contains(&&CharacterKind::Purifier),
+        "tutorial should have a Purifier"
+    );
+}
+
+#[test]
+fn tutorial_allies_are_orin_and_doss() {
+    let enc = scripted_encounter_for(ZoneKind::ResearchWing, 1).unwrap();
+    let ally_kinds: Vec<&CharacterKind> = enc.allies.iter().map(|p| &p.kind).collect();
+    assert!(
+        ally_kinds.contains(&&CharacterKind::Orin),
+        "tutorial allies should include Orin"
+    );
+    assert!(
+        ally_kinds.contains(&&CharacterKind::Doss),
+        "tutorial allies should include Doss"
+    );
+}
+
+#[test]
+fn tutorial_enemies_spawn_on_opposite_side_from_allies() {
+    let enc = scripted_encounter_for(ZoneKind::ResearchWing, 1).unwrap();
+    let cols = 12u32;
+    let rows = 10u32;
+    let enemy_y_avg: f32 = enc
+        .enemies
+        .iter()
+        .map(|p| p.location.to_grid(cols, rows).1 as f32)
+        .sum::<f32>()
+        / enc.enemies.len() as f32;
+    let ally_y_avg: f32 = enc
+        .allies
+        .iter()
+        .map(|p| p.location.to_grid(cols, rows).1 as f32)
+        .sum::<f32>()
+        / enc.allies.len() as f32;
+    assert!(
+        enemy_y_avg < ally_y_avg,
+        "enemies ({enemy_y_avg:.1}) should be on opposite end from allies ({ally_y_avg:.1})"
+    );
+}
+
+#[test]
+fn archon_encounter_returned_for_military_annex_loop4() {
+    let enc = scripted_encounter_for(ZoneKind::MilitaryAnnex, 4);
+    assert!(enc.is_some(), "should have a scripted encounter in loop 4");
+    let enc = enc.unwrap();
+    assert_eq!(enc.id, "archon_encounter");
+}
+
+#[test]
+fn archon_encounter_returned_for_loop5_as_well() {
+    let enc = scripted_encounter_for(ZoneKind::MilitaryAnnex, 5);
+    assert!(enc.is_some());
+    assert_eq!(enc.unwrap().id, "archon_encounter");
+}
+
+#[test]
+fn archon_encounter_has_archon_as_enemy() {
+    let enc = scripted_encounter_for(ZoneKind::MilitaryAnnex, 4).unwrap();
+    assert!(
+        enc.enemies.iter().any(|p| p.kind == CharacterKind::Archon),
+        "archon encounter should include an Archon"
+    );
+}
+
+#[test]
+fn archon_encounter_has_no_allies() {
+    let enc = scripted_encounter_for(ZoneKind::MilitaryAnnex, 4).unwrap();
+    assert!(
+        enc.allies.is_empty(),
+        "archon encounter has no scripted allies"
+    );
+}
+
+#[test]
+fn research_wing_loop2_returns_none() {
+    // After loop 1 the tutorial is done — encounters revert to random.
+    assert!(scripted_encounter_for(ZoneKind::ResearchWing, 2).is_none());
+}
+
+#[test]
+fn military_annex_loop3_returns_none() {
+    // Archon only appears in loop 4+.
+    assert!(scripted_encounter_for(ZoneKind::MilitaryAnnex, 3).is_none());
+}
+
+#[test]
+fn hallway_returns_none() {
+    assert!(scripted_encounter_for(ZoneKind::Hallway, 1).is_none());
+}
+
+// ── ScriptedFirstAction integration ──────────────────────────────────────────
+
+/// Verify that a `ScriptedFirstAction` component causes the AI to use the
+/// named ability on its first combat turn.
+#[test]
+fn scripted_first_action_is_executed_on_first_turn() {
+    let mut world = World::new();
+
+    // Spawn a Researcher with a scripted "Temporal Bolt" first action.
+    let player = world
+        .spawn((
+            Character::new_character(CharacterKind::Researcher, 1),
+            Health::new(75),
+            Stats {
+                max_hp: 75,
+                attack: 20,
+                defense: 4,
+                speed: 16,
+            },
+            ActionPoints::new(4),
+            Position::new(0, 5),
+            ScriptedFirstAction {
+                ability_name: "Temporal Bolt",
+                executed: false,
+            },
+        ))
+        .id();
+
+    // Spawn an enemy directly adjacent so all ability kinds can reach it.
+    world.spawn((
+        Character::new_character(CharacterKind::Scavenger, 1),
+        Health::new(40),
+        Stats {
+            max_hp: 40,
+            attack: 5,
+            defense: 2,
+            speed: 5,
+        },
+        ActionPoints::new(4),
+        Position::new(0, 6),
+    ));
+
+    // Run one full battle step to let the scripted action fire.
+    let mut battle = BattleStep::new(&mut world);
+    let event = battle.step(&mut world);
+
+    // The player's turn should have produced at least one action.
+    assert!(
+        !event.actions.is_empty(),
+        "scripted actor should have acted"
+    );
+
+    // The scripted first action should now be marked executed.
+    let sfa = world.get::<ScriptedFirstAction>(player).unwrap();
+    assert!(
+        sfa.executed,
+        "ScriptedFirstAction should be marked executed after first turn"
+    );
+}
+
+// ── ScriptedAlly despawn ─────────────────────────────────────────────────────
+
+/// Scripted allies should carry the ScriptedAlly marker component.
+#[test]
+fn scripted_allies_have_marker_component() {
+    let mut world = World::new();
+    let ally_entity = world
+        .spawn((
+            Character::new_character(CharacterKind::Orin, 1),
+            Health::new(90),
+            Stats {
+                max_hp: 90,
+                attack: 8,
+                defense: 8,
+                speed: 9,
+            },
+            ActionPoints::new(4),
+            Position::new(5, 8),
+            ScriptedAlly,
+        ))
+        .id();
+
+    assert!(
+        world.get::<ScriptedAlly>(ally_entity).is_some(),
+        "scripted ally should have ScriptedAlly marker"
+    );
+}
+
+// ── BattleStep::current_actor_is_scripted_ally ───────────────────────────────
+
+#[test]
+fn current_actor_is_scripted_ally_returns_false_for_normal_player() {
+    let mut world = World::new();
+    world.spawn((
+        Character::new_character(CharacterKind::Researcher, 1),
+        Health::new(75),
+        Stats {
+            max_hp: 75,
+            attack: 10,
+            defense: 4,
+            speed: 10,
+        },
+        ActionPoints::new(4),
+        Position::new(0, 0),
+    ));
+
+    let battle = BattleStep::new(&mut world);
+    assert!(
+        !battle.current_actor_is_scripted_ally(&world),
+        "regular player should not be considered a scripted ally"
+    );
+}
+
+#[test]
+fn current_actor_is_scripted_ally_returns_true_for_tagged_ally() {
+    let mut world = World::new();
+    // Spawn a scripted ally with a higher speed so it is queued first.
+    world.spawn((
+        Character::new_character(CharacterKind::Orin, 1),
+        Health::new(90),
+        Stats {
+            max_hp: 90,
+            attack: 8,
+            defense: 8,
+            speed: 20, // fast — goes first
+        },
+        ActionPoints::new(4),
+        Position::new(0, 0),
+        ScriptedAlly,
+    ));
+    world.spawn((
+        Character::new_character(CharacterKind::Researcher, 1),
+        Health::new(75),
+        Stats {
+            max_hp: 75,
+            attack: 10,
+            defense: 4,
+            speed: 10,
+        },
+        ActionPoints::new(4),
+        Position::new(1, 0),
+    ));
+
+    let battle = BattleStep::new(&mut world);
+    assert!(
+        battle.current_actor_is_scripted_ally(&world),
+        "scripted ally (fast Orin) should be detected as scripted"
+    );
+}
+
+// ── End-to-end: scripted encounter simulation ─────────────────────────────────
+
+/// Verify that a scripted encounter's enemies and allies survive to be spawned
+/// and that a battle can be simulated to completion.
+#[test]
+fn scripted_tutorial_encounter_can_be_simulated() {
+    use carbonthrone::character::Aggression;
+    let mut world = World::new();
+
+    // Player character.
+    world.spawn((
+        Character::new_character(CharacterKind::Researcher, 5),
+        Health::new(110),
+        Stats {
+            max_hp: 110,
+            attack: 18,
+            defense: 9,
+            speed: 20,
+        },
+        ActionPoints::new(4),
+        Position::new(6, 8),
+    ));
+
+    let enc = scripted_encounter_for(ZoneKind::ResearchWing, 1).unwrap();
+    let cols = 12u32;
+    let rows = 10u32;
+
+    // Spawn enemies from the scripted encounter.
+    for placement in &enc.enemies {
+        let (character, pos) = placement.to_character_and_pos(cols, rows);
+        let stats = character.stats.clone();
+        let hp = character.current_hp;
+        let mut ecmd = world.spawn((character, stats, Health::new(hp), ActionPoints::new(4), pos));
+        if let Some(name) = placement.first_ability {
+            ecmd.insert(ScriptedFirstAction {
+                ability_name: name,
+                executed: false,
+            });
+        }
+    }
+
+    // Spawn allies from the scripted encounter.
+    for placement in &enc.allies {
+        let (mut character, pos) = placement.to_character_and_pos(cols, rows);
+        character.aggression = Aggression::Friendly;
+        let stats = character.stats.clone();
+        let hp = character.current_hp;
+        let mut acmd = world.spawn((
+            character,
+            stats,
+            Health::new(hp),
+            ActionPoints::new(4),
+            pos,
+            ScriptedAlly,
+        ));
+        if let Some(name) = placement.first_ability {
+            acmd.insert(ScriptedFirstAction {
+                ability_name: name,
+                executed: false,
+            });
+        }
+    }
+
+    // The battle should reach an outcome (not run forever).
+    let outcome = simulate_battle(&mut world);
+    assert!(
+        matches!(
+            outcome,
+            BattleOutcome::PlayerVictory | BattleOutcome::PlayerDefeated | BattleOutcome::Draw
+        ),
+        "battle should reach a definite outcome"
+    );
+}


### PR DESCRIPTION
Implements a scripted encounter system for #issue-18.

## Changes

- New `src/scripted_encounter.rs` module with `SpawnLocation`, `CombatantPlacement`, `ScriptedEncounter`, `ScriptedAlly`, `ScriptedFirstAction`
- Two concrete encounters: Loop 1 tutorial fight (ResearchWing) and Archon encounter (MilitaryAnnex, loop 4+)
- Integration into `setup_battle`, `transition_to_battle`, `transition_to_exploration`
- AI support for `ScriptedFirstAction` in `choose_action`
- `BattleStep::current_actor_is_scripted_ally` helper
- 440 lines of integration tests

Closes #18

Generated with [Claude Code](https://claude.ai/code)