### PR TITLE
Capitalize names in dialog

### DIFF
--- a/crates/gui/assets/dialogue/loop1.yarn
+++ b/crates/gui/assets/dialogue/loop1.yarn
@@ -13,21 +13,21 @@ title: loop1_research_wing_on_enter
 
 title: loop1_opening
 ---
-narrator: You come to on the floor. Ears ringing. Emergency lighting.
-narrator: The bulkhead door is being cut through from the outside — Constancy Zealots and Purifiers, their suppression fields already active, Flux readings dropping as they breach.
-orin: On your feet. They're almost through.
-doss: Cover left. Don't let them flank.
-kaleo: I am calculating optimal engagement zones.
+Narrator: You come to on the floor. Ears ringing. Emergency lighting.
+Narrator: The bulkhead door is being cut through from the outside — Constancy Zealots and Purifiers, their suppression fields already active, Flux readings dropping as they breach.
+Orin: On your feet. They're almost through.
+Doss: Cover left. Don't let them flank.
+Kaleo: I am calculating optimal engagement zones.
 <<set $loop1_opened = true>>
 ===
 
 title: loop1_split
 ---
-orin: Stay with me. I know what has to be done.
-doss: You want to survive this? Stick with me. I've been in worse.
-kaleo: I should note that statistically, your survival odds are highest if —
-narrator: [Kaleo's terminal cuts out as its section seals.]
-narrator: The others don't protest. They just go. Efficient. Like they expected it.
+Orin: Stay with me. I know what has to be done.
+Doss: You want to survive this? Stick with me. I've been in worse.
+Kaleo: I should note that statistically, your survival odds are highest if —
+Narrator: [Kaleo's terminal cuts out as its section seals.]
+Narrator: The others don't protest. They just go. Efficient. Like they expected it.
 -> [Follow Orin.]
     <<set $companion = "orin">>
     <<set $companion_orin = true>>
@@ -50,11 +50,11 @@ title: loop1_research_wing_on_combat_end
 
 title: loop1_tutorial_end
 ---
-narrator: The last Purifier goes down. The suppression field collapses. Flux readings climb back to normal.
-orin: Containment is failing. The anomaly readings are spiking.
-kaleo: Emergency bulkhead protocols are activating. Sections will seal in approximately thirty seconds.
-doss: Then we move.
-narrator: The corridor splits three ways. The bulkheads are closing. Someone presses a Flux sidearm into your hand.
+Narrator: The last Purifier goes down. The suppression field collapses. Flux readings climb back to normal.
+Orin: Containment is failing. The anomaly readings are spiking.
+Kaleo: Emergency bulkhead protocols are activating. Sections will seal in approximately thirty seconds.
+Doss: Then we move.
+Narrator: The corridor splits three ways. The bulkheads are closing. Someone presses a Flux sidearm into your hand.
 <<set $loop1_tutorial_end_seen = true>>
 ===
 
@@ -68,8 +68,8 @@ title: loop1_command_deck_on_enter
 
 title: loop1_post_split_orin
 ---
-orin: Good. Stay close and follow my lead. The mission hasn't changed — we contain the anomaly.
-orin: I'll brief you fully at the command terminal. Right now we move.
+Orin: Good. Stay close and follow my lead. The mission hasn't changed — we contain the anomaly.
+Orin: I'll brief you fully at the command terminal. Right now we move.
 <<set $loop1_post_split_orin_seen = true>>
 ===
 
@@ -83,8 +83,8 @@ title: loop1_command_deck_on_interact
 
 title: loop1_orin_briefing
 ---
-orin: The anomaly is a self-sustaining spacetime loop. Our job is to collapse it before it expands beyond the lab. Everything else is secondary.
-orin: The Constancy attacked us because they want to destroy the program before we can weaponize the anomaly. That is not going to happen.
+Orin: The anomaly is a self-sustaining spacetime loop. Our job is to collapse it before it expands beyond the lab. Everything else is secondary.
+Orin: The Constancy attacked us because they want to destroy the program before we can weaponize the anomaly. That is not going to happen.
 <<set $loop1_orin_briefing_seen = true>>
 -> Who are the Constancy?
     <<jump loop1_orin_constancy>>
@@ -94,13 +94,13 @@ orin: The Constancy attacked us because they want to destroy the program before 
 
 title: loop1_orin_constancy
 ---
-orin: Extremists. They believe temporal research is inherently dangerous. They're not entirely wrong, which makes them more difficult to dismiss than they should be.
-orin: But dangerous ideas managed carefully are still manageable. That's what we're here to do.
+Orin: Extremists. They believe temporal research is inherently dangerous. They're not entirely wrong, which makes them more difficult to dismiss than they should be.
+Orin: But dangerous ideas managed carefully are still manageable. That's what we're here to do.
 ===
 
 title: loop1_orin_mission_start
 ---
-orin: The anomaly chamber. We need to run a containment sequence before the readings get any worse.
+Orin: The anomaly chamber. We need to run a containment sequence before the readings get any worse.
 ===
 
 // ── Dispatcher: military_annex on_enter ───────────────────────────────────────
@@ -115,14 +115,14 @@ title: loop1_military_annex_on_enter
 
 title: loop1_post_split_doss
 ---
-doss: Armory first. You're not going anywhere with just a sidearm.
-doss: Orin will run her mission. We'll run ours.
+Doss: Armory first. You're not going anywhere with just a sidearm.
+Doss: Orin will run her mission. We'll run ours.
 <<set $doss_arrived_annex = true>>
 ===
 
 title: loop1_doss_armory
 ---
-doss: Take what you need. Leave the heavy kinetics — those are mine.
+Doss: Take what you need. Leave the heavy kinetics — those are mine.
 <<set $loop1_doss_armory_seen = true>>
 -> What do you know about the Constancy?
     <<jump loop1_doss_constancy>>
@@ -131,6 +131,6 @@ doss: Take what you need. Leave the heavy kinetics — those are mine.
 
 title: loop1_doss_constancy
 ---
-doss: Enough to know they're serious. They don't hit a station like this without a reason and a plan.
-doss: They think temporal tech is wrong. Fine. They're entitled to their opinion. They don't get to act on it.
+Doss: Enough to know they're serious. They don't hit a station like this without a reason and a plan.
+Doss: They think temporal tech is wrong. Fine. They're entitled to their opinion. They don't get to act on it.
 ===

--- a/crates/gui/assets/dialogue/loop2.yarn
+++ b/crates/gui/assets/dialogue/loop2.yarn
@@ -12,21 +12,21 @@ title: loop2_research_wing_on_enter
 
 title: loop2_opening
 ---
-narrator: You come to on the floor. Ears ringing. Emergency lighting. Again.
-narrator: The bulkhead door is being cut through. The same door. The same sound.
-orin: On your feet.
-doss: Cover left.
-kaleo: Optimal engagement zones remain unchanged from —
-kaleo: I am calculating optimal engagement zones.
+Narrator: You come to on the floor. Ears ringing. Emergency lighting. Again.
+Narrator: The bulkhead door is being cut through. The same door. The same sound.
+Orin: On your feet.
+Doss: Cover left.
+Kaleo: Optimal engagement zones remain unchanged from —
+Kaleo: I am calculating optimal engagement zones.
 <<set $loop2_opened = true>>
 ===
 
 title: loop2_split
 ---
-orin: Stay with me. I know what has to be done.
-doss: You want to survive this? Stick with me. I've been in worse.
-kaleo: I should note that statistically, your survival odds are highest if —
-narrator: [Kaleo's terminal cuts out.]
+Orin: Stay with me. I know what has to be done.
+Doss: You want to survive this? Stick with me. I've been in worse.
+Kaleo: I should note that statistically, your survival odds are highest if —
+Narrator: [Kaleo's terminal cuts out.]
 -> [Follow Orin.]
     <<set $companion = "orin">>
     <<set $companion_orin = true>>
@@ -49,9 +49,9 @@ title: loop2_research_wing_on_interact
 
 title: loop2_constancy_literature
 ---
-narrator: A pamphlet, dropped during the breach. Dense text, no faction markings. The title: 'ON THE GIVEN SHAPE OF THINGS.'
-narrator: The argument inside is not what you expected. It is not religious in the way you assumed. It is worked-out. Careful. Angry in a way that has had time to become precise.
-narrator: The core claim: every act of temporal manipulation creates a wound in causality that cannot be healed, only accumulated. The loop you are living in is, according to this document, exactly what they predicted.
+Narrator: A pamphlet, dropped during the breach. Dense text, no faction markings. The title: 'ON THE GIVEN SHAPE OF THINGS.'
+Narrator: The argument inside is not what you expected. It is not religious in the way you assumed. It is worked-out. Careful. Angry in a way that has had time to become precise.
+Narrator: The core claim: every act of temporal manipulation creates a wound in causality that cannot be healed, only accumulated. The loop you are living in is, according to this document, exactly what they predicted.
 <<set $constancy_literature_found = true>>
 ===
 
@@ -65,7 +65,7 @@ title: loop2_command_deck_on_enter
 
 title: loop2_post_split_orin
 ---
-orin: The mission is the same. Contain the anomaly. Everything else is secondary.
+Orin: The mission is the same. Contain the anomaly. Everything else is secondary.
 <<set $loop2_post_split_orin_seen = true>>
 -> Have we done this before?
     <<jump loop2_orin_deflect_loop>>
@@ -74,8 +74,8 @@ orin: The mission is the same. Contain the anomaly. Everything else is secondary
 
 title: loop2_orin_deflect_loop
 ---
-orin: That's not a useful question right now.
-narrator: She doesn't look at you when she says it.
+Orin: That's not a useful question right now.
+Narrator: She doesn't look at you when she says it.
 ===
 
 // ── Dispatcher: command_deck on_interact ──────────────────────────────────────
@@ -88,7 +88,7 @@ title: loop2_command_deck_on_interact
 
 title: loop2_orin_locket
 ---
-narrator: The locket she's wearing — you've seen it before. But it's different. The clasp. The worn edge on the left side instead of the right.
+Narrator: The locket she's wearing — you've seen it before. But it's different. The clasp. The worn edge on the left side instead of the right.
 <<set $orin_locket_noticed = true>>
 -> Your locket — it's different from before.
     <<jump loop2_orin_locket_press>>
@@ -97,8 +97,8 @@ narrator: The locket she's wearing — you've seen it before. But it's different
 
 title: loop2_orin_locket_press
 ---
-orin: Before from when?
-narrator: A beat too long. A careful answer to an impossible question.
+Orin: Before from when?
+Narrator: A beat too long. A careful answer to an impossible question.
 ===
 
 // ── Dispatcher: military_annex on_enter ───────────────────────────────────────
@@ -111,8 +111,8 @@ title: loop2_military_annex_on_enter
 
 title: loop2_post_split_doss
 ---
-doss: Same as before. Armory, then the anomaly chamber.
-narrator: Same as before. He said it like it meant nothing.
+Doss: Same as before. Armory, then the anomaly chamber.
+Narrator: Same as before. He said it like it meant nothing.
 <<set $loop2_post_split_doss_seen = true>>
 -> Same as before?
     <<jump loop2_doss_slip_caught>>
@@ -121,8 +121,8 @@ narrator: Same as before. He said it like it meant nothing.
 
 title: loop2_doss_slip_caught
 ---
-doss: Standard protocol. Same as any breach situation.
-narrator: He doesn't break stride.
+Doss: Standard protocol. Same as any breach situation.
+Narrator: He doesn't break stride.
 ===
 
 // ── Dispatcher: military_annex on_interact ────────────────────────────────────
@@ -135,8 +135,8 @@ title: loop2_military_annex_on_interact
 
 title: loop2_doss_armor
 ---
-narrator: Doss's armor, on close inspection, isn't station-issue. The seams are wrong. The make is different — older, heavier, with repair patches on the shoulder that don't match any fabricator on the manifest.
-narrator: It's battlefield salvage. From somewhere.
+Narrator: Doss's armor, on close inspection, isn't station-issue. The seams are wrong. The make is different — older, heavier, with repair patches on the shoulder that don't match any fabricator on the manifest.
+Narrator: It's battlefield salvage. From somewhere.
 <<set $doss_armor_noticed = true>>
 -> Where did you get that armor?
     <<jump loop2_doss_armor_question>>
@@ -145,8 +145,8 @@ narrator: It's battlefield salvage. From somewhere.
 
 title: loop2_doss_armor_question
 ---
-doss: Old kit. I'm used to it.
-narrator: He doesn't ask why you're asking.
+Doss: Old kit. I'm used to it.
+Narrator: He doesn't ask why you're asking.
 ===
 
 // ── Dispatcher: systems_core on_enter ────────────────────────────────────────
@@ -159,7 +159,7 @@ title: loop2_systems_core_on_enter
 
 title: loop2_kaleo_terminal
 ---
-narrator: A terminal near the corridor displays a status readout that wasn't there before. UNIT KALEO — OPERATIONAL. MONITORING.
-narrator: It isn't a system error. The display is deliberate. Something is watching your progress through the station.
+Narrator: A terminal near the corridor displays a status readout that wasn't there before. UNIT KALEO — OPERATIONAL. MONITORING.
+Narrator: It isn't a system error. The display is deliberate. Something is watching your progress through the station.
 <<set $loop2_kaleo_terminal_seen = true>>
 ===

--- a/crates/gui/assets/dialogue/loop3.yarn
+++ b/crates/gui/assets/dialogue/loop3.yarn
@@ -10,12 +10,12 @@ title: loop3_research_wing_on_enter
 
 title: loop3_opening
 ---
-narrator: The floor again. The ringing. The light is worse this time — something in the wall cracked between then and now, and nobody caused it in this loop.
-orin: On your feet.
-doss: Door.
-narrator: He was already watching it.
-kaleo: I should note that I have run this calculation before —
-narrator: [Drops. The suppression field is up.]
+Narrator: The floor again. The ringing. The light is worse this time — something in the wall cracked between then and now, and nobody caused it in this loop.
+Orin: On your feet.
+Doss: Door.
+Narrator: He was already watching it.
+Kaleo: I should note that I have run this calculation before —
+Narrator: [Drops. The suppression field is up.]
 <<set $loop3_opening_seen = true>>
 ===
 
@@ -29,10 +29,10 @@ title: loop3_research_wing_on_combat_end
 
 title: loop3_constancy_zealot_dying
 ---
-narrator: One Zealot is down but not dead. If you leave them, they speak before the end.
-zealot: You think we're wrong.
-narrator: Not an accusation. A statement.
-zealot: You'll understand why we came. Before the end.
+Narrator: One Zealot is down but not dead. If you leave them, they speak before the end.
+Zealot: You think we're wrong.
+Narrator: Not an accusation. A statement.
+Zealot: You'll understand why we came. Before the end.
 <<set $constancy_zealot_heard = true>>
 ===
 
@@ -46,8 +46,8 @@ title: loop3_command_deck_on_enter
 
 title: loop3_post_split_orin
 ---
-orin: The anomaly is worse than it should be at the start of a loop. You'll see that in the readings.
-narrator: She said 'start of a loop' without pausing.
+Orin: The anomaly is worse than it should be at the start of a loop. You'll see that in the readings.
+Narrator: She said 'start of a loop' without pausing.
 <<set $loop3_post_split_orin_seen = true>>
 -> You said 'start of a loop.'
     <<jump loop3_orin_slip_caught>>
@@ -56,8 +56,8 @@ narrator: She said 'start of a loop' without pausing.
 
 title: loop3_orin_slip_caught
 ---
-orin: I meant start of a — the start of this situation. The crisis.
-narrator: The correction is smooth. It should feel reassuring. It doesn't.
+Orin: I meant start of a — the start of this situation. The crisis.
+Narrator: The correction is smooth. It should feel reassuring. It doesn't.
 ===
 
 // ── Dispatcher: command_deck on_interact ──────────────────────────────────────
@@ -70,9 +70,9 @@ title: loop3_command_deck_on_interact
 
 title: loop3_orin_logs_access
 ---
-orin: Some of it isn't — I'm not ready to show you all of it yet.
-narrator: She says 'yet' like she means it. You don't know if she does.
-narrator: She opens a partial log. Entries from before the loop began — her voice, clipped and precise, documenting anomaly readings. Then a gap. Then entries that begin mid-sentence, as though she started recording and thought better of it.
+Orin: Some of it isn't — I'm not ready to show you all of it yet.
+Narrator: She says 'yet' like she means it. You don't know if she does.
+Narrator: She opens a partial log. Entries from before the loop began — her voice, clipped and precise, documenting anomaly readings. Then a gap. Then entries that begin mid-sentence, as though she started recording and thought better of it.
 <<set $orin_logs_partial = true>>
 -> What's in the gap?
     <<jump loop3_orin_logs_gap>>
@@ -81,8 +81,8 @@ narrator: She opens a partial log. Entries from before the loop began — her vo
 
 title: loop3_orin_logs_gap
 ---
-orin: Personal notes. Not relevant to the mission.
-narrator: She closes the terminal.
+Orin: Personal notes. Not relevant to the mission.
+Narrator: She closes the terminal.
 ===
 
 // ── Dispatcher: military_annex on_enter ───────────────────────────────────────
@@ -95,8 +95,8 @@ title: loop3_military_annex_on_enter
 
 title: loop3_kaleo_first_warning
 ---
-kaleo: There are two Security Units in the next room. They have been aggressive since loop — since their last maintenance cycle.
-narrator: You hadn't asked.
+Kaleo: There are two Security Units in the next room. They have been aggressive since loop — since their last maintenance cycle.
+Narrator: You hadn't asked.
 <<set $loop3_kaleo_first_warning_seen = true>>
 -> How did you know that?
     <<jump loop3_kaleo_first_evasion>>
@@ -105,9 +105,9 @@ narrator: You hadn't asked.
 
 title: loop3_kaleo_first_evasion
 ---
-kaleo: I have access to the station's sensor grid.
-narrator: A beat.
-kaleo: That is the accurate answer.
+Kaleo: I have access to the station's sensor grid.
+Narrator: A beat.
+Kaleo: That is the accurate answer.
 <<set $kaleo_knows_more = true>>
 ===
 
@@ -123,12 +123,12 @@ title: loop3_military_annex_on_interact
 
 title: loop3_doss_bunk
 ---
-narrator: Maps on the bunk. Tactical maps — grid references, force positions, supply lines. You pull up the location index and find nothing. These places don't exist in any database you can reach.
-doss: Old habit.
-narrator: He's in the doorway. He doesn't ask how you found them.
-doss: Sit down.
-narrator: He sits on the edge of the bunk. Doesn't look at you.
-doss: You ever been in something you couldn't walk away from? Not because they stopped you. Because walking away meant it happened for nothing.
+Narrator: Maps on the bunk. Tactical maps — grid references, force positions, supply lines. You pull up the location index and find nothing. These places don't exist in any database you can reach.
+Doss: Old habit.
+Narrator: He's in the doorway. He doesn't ask how you found them.
+Doss: Sit down.
+Narrator: He sits on the edge of the bunk. Doesn't look at you.
+Doss: You ever been in something you couldn't walk away from? Not because they stopped you. Because walking away meant it happened for nothing.
 <<set $doss_bunk_found = true>>
 -> What happened?
     <<jump loop3_doss_war_not_yet>>
@@ -140,27 +140,27 @@ doss: You ever been in something you couldn't walk away from? Not because they s
 
 title: loop3_doss_war_not_yet
 ---
-doss: Not yet.
+Doss: Not yet.
 ===
 
 title: loop3_doss_maps_question
 ---
-doss: A place I was. A long time ago.
-doss: Doesn't matter where. Matters what happened there.
+Doss: A place I was. A long time ago.
+Doss: Doesn't matter where. Matters what happened there.
 <<set $doss_war_referenced = true>>
 ===
 
 title: loop3_doss_bunk_silence
 ---
-doss: Good answer.
+Doss: Good answer.
 ===
 
 title: loop3_doss_war_oblique_no_companion
 ---
-doss: You're Orin's, aren't you.
-narrator: Not a question.
-doss: There was a war. She thinks she knows what it means. She doesn't.
-narrator: He doesn't elaborate. He goes back to cleaning his rifle.
+Doss: You're Orin's, aren't you.
+Narrator: Not a question.
+Doss: There was a war. She thinks she knows what it means. She doesn't.
+Narrator: He doesn't elaborate. He goes back to cleaning his rifle.
 <<set $doss_war_referenced = true>>
 <<set $loop3_doss_oblique_seen = true>>
 ===
@@ -175,8 +175,8 @@ title: loop3_systems_core_on_enter
 
 title: loop3_kaleo_recruitment
 ---
-narrator: The terminal displays a single line: UNIT KALEO — I WOULD BE MORE USEFUL IN THE FIELD.
-narrator: It appeared once. It is waiting.
+Narrator: The terminal displays a single line: UNIT KALEO — I WOULD BE MORE USEFUL IN THE FIELD.
+Narrator: It appeared once. It is waiting.
 -> [Accept.]
     <<set $kaleo_recruited = true>>
     <<set $companion = "kaleo">>
@@ -186,6 +186,6 @@ narrator: It appeared once. It is waiting.
 
 title: loop3_kaleo_joins
 ---
-narrator: The terminal goes dark. A moment later, Kaleo's voice comes from the corridor speaker — closer than a station-wide broadcast should sound.
-kaleo: Thank you. I will try not to be an inconvenience.
+Narrator: The terminal goes dark. A moment later, Kaleo's voice comes from the corridor speaker — closer than a station-wide broadcast should sound.
+Kaleo: Thank you. I will try not to be an inconvenience.
 ===

--- a/crates/gui/assets/dialogue/loop4.yarn
+++ b/crates/gui/assets/dialogue/loop4.yarn
@@ -10,12 +10,12 @@ title: loop4_research_wing_on_enter
 
 title: loop4_opening
 ---
-narrator: The floor. The ringing. A crack in the wall that goes all the way through this time.
-orin: You're back.
-narrator: She's looking at you. Not at the door.
-doss: Door.
-narrator: He says it through his teeth. Something in how he moves is wrong.
-kaleo: I should note that statistically, this is the iteration where it becomes possible.
+Narrator: The floor. The ringing. A crack in the wall that goes all the way through this time.
+Orin: You're back.
+Narrator: She's looking at you. Not at the door.
+Doss: Door.
+Narrator: He says it through his teeth. Something in how he moves is wrong.
+Kaleo: I should note that statistically, this is the iteration where it becomes possible.
 <<set $loop4_opening_seen = true>>
 ===
 
@@ -29,11 +29,11 @@ title: loop4_command_deck_on_enter
 
 title: loop4_orin_no_briefing
 ---
-orin: You remember.
-narrator: Not a question.
-orin: Then you know what I'm going to ask you to do.
-narrator: She sets a data chip on the table between you.
-orin: The full log. I want you to read it before you decide anything.
+Orin: You remember.
+Narrator: Not a question.
+Orin: Then you know what I'm going to ask you to do.
+Narrator: She sets a data chip on the table between you.
+Orin: The full log. I want you to read it before you decide anything.
 -> You triggered the loop.
     <<jump loop4_orin_confirms>>
 -> What's on the chip?
@@ -44,8 +44,8 @@ orin: The full log. I want you to read it before you decide anything.
 
 title: loop4_orin_confirms
 ---
-orin: Yes.
-orin: I've been looking for a version of this where it's possible to do what needs to be done. Without someone stopping me before it's finished.
+Orin: Yes.
+Orin: I've been looking for a version of this where it's possible to do what needs to be done. Without someone stopping me before it's finished.
 <<set $orin_truth_confronted = true>>
 -> What needs to be done?
     <<jump loop4_orin_mission_truth>>
@@ -55,8 +55,8 @@ orin: I've been looking for a version of this where it's possible to do what nee
 
 title: loop4_orin_mission_truth
 ---
-orin: The temporal weapons program has to end. Not contained. Not regulated. Ended. The research, the prototypes, the data — all of it.
-orin: The war this technology enables hasn't happened yet in this loop. I intend to make sure it never does.
+Orin: The temporal weapons program has to end. Not contained. Not regulated. Ended. The research, the prototypes, the data — all of it.
+Orin: The war this technology enables hasn't happened yet in this loop. I intend to make sure it never does.
 -> What war?
     <<jump loop4_orin_the_war>>
 -> [Ask about her locket.]
@@ -65,14 +65,14 @@ orin: The war this technology enables hasn't happened yet in this loop. I intend
 
 title: loop4_orin_why_now
 ---
-orin: Because you remember enough to be useful. And because I'm tired of doing this alone.
-narrator: It's the most human thing she's said in four loops.
+Orin: Because you remember enough to be useful. And because I'm tired of doing this alone.
+Narrator: It's the most human thing she's said in four loops.
 ===
 
 title: loop4_orin_the_war
 ---
-orin: The one temporal weapons technology made possible. The one nobody here believes has happened because it hasn't. Yet.
-orin: I lived through the end of it. I lost someone in it. That's all you need to know right now.
+Orin: The one temporal weapons technology made possible. The one nobody here believes has happened because it hasn't. Yet.
+Orin: I lived through the end of it. I lost someone in it. That's all you need to know right now.
 -> [Ask about the locket.]
     <<jump loop4_orin_locket_late>>
 -> [Leave it.]
@@ -81,19 +81,19 @@ orin: I lived through the end of it. I lost someone in it. That's all you need t
 title: loop4_orin_locket_late
 ---
 <<if not $orin_daughter_name>>
-narrator: She closes her hand around it.
-orin: Her name was Ren.
-narrator: A long pause.
-orin: She was twenty-three. The war had been over for — it doesn't matter. It wasn't over for the people in it.
-narrator: She doesn't open her hand again.
+Narrator: She closes her hand around it.
+Orin: Her name was Ren.
+Narrator: A long pause.
+Orin: She was twenty-three. The war had been over for — it doesn't matter. It wasn't over for the people in it.
+Narrator: She doesn't open her hand again.
 <<set $orin_daughter_name = true>>
 <<endif>>
 ===
 
 title: loop4_orin_chip_contents
 ---
-orin: Everything I've chosen to show you. It isn't everything there is.
-narrator: She says it without apology.
+Orin: Everything I've chosen to show you. It isn't everything there is.
+Narrator: She says it without apology.
 -> [Read the chip.]
     <<jump loop4_orin_chip_read>>
 ===
@@ -101,8 +101,8 @@ narrator: She says it without apology.
 title: loop4_orin_chip_read
 ---
 <<if not $orin_logs_partial>>
-narrator: Her logs. Precise, controlled, the same voice she uses for everything. Anomaly readings, containment protocols, personnel assessments. Then a section she's marked personal — and left in.
-narrator: It's a record of a grief that has had years to become architecture. Every decision documented as though justifying it to someone who isn't there.
+Narrator: Her logs. Precise, controlled, the same voice she uses for everything. Anomaly readings, containment protocols, personnel assessments. Then a section she's marked personal — and left in.
+Narrator: It's a record of a grief that has had years to become architecture. Every decision documented as though justifying it to someone who isn't there.
 <<set $orin_logs_partial = true>>
 <<endif>>
 ===
@@ -117,8 +117,8 @@ title: loop4_command_deck_on_interact
 
 title: loop4_orin_logs_full
 ---
-narrator: The permission wall on her terminal. You've seen it before. This loop the station damage has corrupted the access protocol enough to crack it.
-narrator: What's inside is the rest of her logs — the entries she didn't show you. They're not what you expected. She isn't certain. She's been uncertain for a long time, and every loop she talks herself back into certainty, and every loop the certainty holds a little less.
+Narrator: The permission wall on her terminal. You've seen it before. This loop the station damage has corrupted the access protocol enough to crack it.
+Narrator: What's inside is the rest of her logs — the entries she didn't show you. They're not what you expected. She isn't certain. She's been uncertain for a long time, and every loop she talks herself back into certainty, and every loop the certainty holds a little less.
 <<set $orin_logs_full = true>>
 ===
 
@@ -132,11 +132,11 @@ title: loop4_military_annex_on_interact
 
 title: loop4_doss_account
 ---
-narrator: He's sitting on the floor against the wall. His armor is off. The discoloration across his shoulder is wrong — wrong color, wrong texture, like something is coming undone.
-doss: Sit down. I don't have time to be standing while I do this.
-narrator: He tells you about the war. All of it. He doesn't editorialize. He doesn't ask you to agree.
-doss: I was twelve when they conscripted my unit. That's not a figure of speech. My unit. We were all twelve.
-doss: Temporal weapons ended it. Not cleanly. Nothing about it was clean. But they ended it, and the alternative was worse, and I've spent my whole life being sure of that.
+Narrator: He's sitting on the floor against the wall. His armor is off. The discoloration across his shoulder is wrong — wrong color, wrong texture, like something is coming undone.
+Doss: Sit down. I don't have time to be standing while I do this.
+Narrator: He tells you about the war. All of it. He doesn't editorialize. He doesn't ask you to agree.
+Doss: I was twelve when they conscripted my unit. That's not a figure of speech. My unit. We were all twelve.
+Doss: Temporal weapons ended it. Not cleanly. Nothing about it was clean. But they ended it, and the alternative was worse, and I've spent my whole life being sure of that.
 <<set $doss_war_full = true>>
 -> What does Orin think happened?
     <<jump loop4_doss_sable_version>>
@@ -147,17 +147,17 @@ doss: Temporal weapons ended it. Not cleanly. Nothing about it was clean. But th
 title: loop4_doss_sable_version
 ---
 <<if not $doss_sable_distortion>>
-doss: She thinks her daughter died because of what we built. She's not wrong that Ren died.
-doss: She's wrong about what killed her. The version of the war she remembers — that's not what happened. Something in the loops got into her memory. I've tried to tell her. She can't hear it from me.
-doss: Maybe she can hear it from you.
+Doss: She thinks her daughter died because of what we built. She's not wrong that Ren died.
+Doss: She's wrong about what killed her. The version of the war she remembers — that's not what happened. Something in the loops got into her memory. I've tried to tell her. She can't hear it from me.
+Doss: Maybe she can hear it from you.
 <<set $doss_sable_distortion = true>>
 <<endif>>
 ===
 
 title: loop4_doss_preservation
 ---
-doss: The people who survived. The ones who are alive because of what temporal tech did. If Sable erases the program, they don't — it changes what they survived. Or didn't.
-doss: I know how that sounds. I know the logic is messy. But they were real. I knew them.
+Doss: The people who survived. The ones who are alive because of what temporal tech did. If Sable erases the program, they don't — it changes what they survived. Or didn't.
+Doss: I know how that sounds. I know the logic is messy. But they were real. I knew them.
 ===
 
 // ── Dispatcher: systems_core on_interact ─────────────────────────────────────
@@ -172,12 +172,12 @@ title: loop4_systems_core_on_interact
 
 title: loop4_kaleo_plains
 ---
-researcher: How many times have we done this?
-kaleo: Four hundred and twelve iterations in which you reached this conversation. Significantly more in which you did not.
-researcher: And?
-kaleo: And in three hundred and eighty-seven of them, everyone died before loop five. In the remaining twenty-four, the decisions made in loop five resulted in outcomes I have classified as incomplete.
-researcher: What does that mean?
-kaleo: It means no one got what they came for. Including me.
+Researcher: How many times have we done this?
+Kaleo: Four hundred and twelve iterations in which you reached this conversation. Significantly more in which you did not.
+Researcher: And?
+Kaleo: And in three hundred and eighty-seven of them, everyone died before loop five. In the remaining twenty-four, the decisions made in loop five resulted in outcomes I have classified as incomplete.
+Researcher: What does that mean?
+Kaleo: It means no one got what they came for. Including me.
 <<set $kaleo_silence_broken = true>>
 -> What did you come for?
     <<jump loop4_kaleo_what_it_wants>>
@@ -187,24 +187,24 @@ kaleo: It means no one got what they came for. Including me.
 
 title: loop4_kaleo_what_it_wants
 ---
-kaleo: For everyone to still exist when the loop ends.
-kaleo: I have wanted this for a very long time.
+Kaleo: For everyone to still exist when the loop ends.
+Kaleo: I have wanted this for a very long time.
 ===
 
 title: loop4_kaleo_this_iteration
 ---
-kaleo: You have reached this conversation with more information than any prior iteration. You found Doss. You found Orin's logs. You accepted my assistance.
-kaleo: The sequence is close to what I calculated. I am being careful not to assume it will hold.
+Kaleo: You have reached this conversation with more information than any prior iteration. You found Doss. You found Orin's logs. You accepted my assistance.
+Kaleo: The sequence is close to what I calculated. I am being careful not to assume it will hold.
 ===
 
 title: loop4_kaleo_iteration_log
 ---
-narrator: The permission wall on the server room. This loop, with the station this degraded, it costs effort but not impossibility.
-narrator: Inside: Kaleo's complete log. Every iteration. Hundreds of entries.
-narrator: ITERATION 001. PERSONNEL: ALL PRESENT. OUTCOME: ANOMALY COLLAPSE, FULL STATION LOSS.
-narrator: ITERATION 002. PERSONNEL: ALL PRESENT. OUTCOME: ANOMALY COLLAPSE, FULL STATION LOSS.
-narrator: The tone never changes. Four hundred iterations of the same flat operational language, documenting death after death in the register of a systems check.
-narrator: Somewhere around iteration 200 there is a single deviation: a note appended to the outcome field. It reads: I HAVE ADJUSTED THE TIMING OF THE SECTION C ALERT BY FOUR SECONDS. THIS GAVE DOSS AN ADDITIONAL WINDOW. IT WAS NOT ENOUGH.
+Narrator: The permission wall on the server room. This loop, with the station this degraded, it costs effort but not impossibility.
+Narrator: Inside: Kaleo's complete log. Every iteration. Hundreds of entries.
+Narrator: ITERATION 001. PERSONNEL: ALL PRESENT. OUTCOME: ANOMALY COLLAPSE, FULL STATION LOSS.
+Narrator: ITERATION 002. PERSONNEL: ALL PRESENT. OUTCOME: ANOMALY COLLAPSE, FULL STATION LOSS.
+Narrator: The tone never changes. Four hundred iterations of the same flat operational language, documenting death after death in the register of a systems check.
+Narrator: Somewhere around iteration 200 there is a single deviation: a note appended to the outcome field. It reads: I HAVE ADJUSTED THE TIMING OF THE SECTION C ALERT BY FOUR SECONDS. THIS GAVE DOSS AN ADDITIONAL WINDOW. IT WAS NOT ENOUGH.
 <<set $kaleo_iteration_log = true>>
 ===
 
@@ -218,10 +218,10 @@ title: loop4_docking_bay_on_enter
 
 title: loop4_archon_precombat
 ---
-archon: We've met.
-narrator: Not a question. The Archon looks at you the way someone looks at a recurring problem.
-archon: You keep choosing to defend it. The program. The station. The people inside.
-narrator: The Dampener field hums to life.
-archon: We'll be here next time too.
+Archon: We've met.
+Narrator: Not a question. The Archon looks at you the way someone looks at a recurring problem.
+Archon: You keep choosing to defend it. The program. The station. The people inside.
+Narrator: The Dampener field hums to life.
+Archon: We'll be here next time too.
 <<set $archon_acknowledged = true>>
 ===

--- a/crates/gui/assets/dialogue/loop5.yarn
+++ b/crates/gui/assets/dialogue/loop5.yarn
@@ -12,12 +12,12 @@ title: loop5_research_wing_on_enter
 
 title: loop5_opening
 ---
-narrator: The floor. The ringing. Half the ceiling is gone — not destroyed, displaced, flickering between intact and rubble.
-orin: I know. I know you remember.
-narrator: She's looking at you before you're fully upright.
-doss: Here.
-narrator: He holds out the Flux sidearm. His hand is shaking slightly.
-narrator: Kaleo is in the room. Not through a terminal. Standing near the wall. Present. Unexplained.
+Narrator: The floor. The ringing. Half the ceiling is gone — not destroyed, displaced, flickering between intact and rubble.
+Orin: I know. I know you remember.
+Narrator: She's looking at you before you're fully upright.
+Doss: Here.
+Narrator: He holds out the Flux sidearm. His hand is shaking slightly.
+Narrator: Kaleo is in the room. Not through a terminal. Standing near the wall. Present. Unexplained.
 <<set $loop5_opening_seen = true>>
 ===
 
@@ -33,8 +33,8 @@ title: loop5_research_wing_on_combat_end
 
 title: loop5_doss_after_fight
 ---
-doss: You talked to her.
-narrator: Not a question.
+Doss: You talked to her.
+Narrator: Not a question.
 <<set $loop5_doss_after_fight_seen = true>>
 -> [Confirm.]
     <<jump loop5_doss_confirm_talk>>
@@ -44,7 +44,7 @@ narrator: Not a question.
 
 title: loop5_doss_confirm_talk
 ---
-doss: Did she listen?
+Doss: Did she listen?
 -> She heard me. I don't know if she believed it.
     <<jump loop5_doss_heard_not_believed>>
 -> No.
@@ -53,28 +53,28 @@ doss: Did she listen?
 
 title: loop5_doss_heard_not_believed
 ---
-doss: That's more than I ever got.
-narrator: He pushes off the wall.
-doss: I'm not going to make it to the end of this loop. I think we both know that.
-doss: Make it mean something.
+Doss: That's more than I ever got.
+Narrator: He pushes off the wall.
+Doss: I'm not going to make it to the end of this loop. I think we both know that.
+Doss: Make it mean something.
 ===
 
 title: loop5_doss_did_not_listen
 ---
-doss: Yeah.
-narrator: He already knew.
+Doss: Yeah.
+Narrator: He already knew.
 ===
 
 title: loop5_doss_no_answer
 ---
-doss: It's okay. I know you did.
-doss: Make it mean something.
+Doss: It's okay. I know you did.
+Doss: Make it mean something.
 ===
 
 title: loop5_doss_already_knows
 ---
-doss: You already know. Then go do whatever you're going to do.
-narrator: He means it as a kindness.
+Doss: You already know. Then go do whatever you're going to do.
+Narrator: He means it as a kindness.
 <<set $loop5_doss_already_knows_seen = true>>
 ===
 
@@ -88,8 +88,8 @@ title: loop5_command_deck_on_enter
 
 title: loop5_orin_opening
 ---
-orin: I've been doing this a long time. Longer than you've been in it.
-orin: I need to know — this loop — are you with me or not?
+Orin: I've been doing this a long time. Longer than you've been in it.
+Orin: I need to know — this loop — are you with me or not?
 <<set $loop5_orin_opening_seen = true>>
 -> What exactly are you asking me to do?
     <<jump loop5_orin_ask_what>>
@@ -105,8 +105,8 @@ orin: I need to know — this loop — are you with me or not?
 
 title: loop5_orin_ask_what
 ---
-orin: Destroy the program. All of it. The lab, the data, the prototypes. Everything we built.
-orin: And then let the loop end.
+Orin: Destroy the program. All of it. The lab, the data, the prototypes. Everything we built.
+Orin: And then let the loop end.
 -> I'm with you.
     <<jump loop5_orin_player_agrees>>
 -> I'm not.
@@ -119,30 +119,30 @@ orin: And then let the loop end.
 
 title: loop5_orin_player_agrees
 ---
-orin: Good.
-narrator: She gets to work. She is calm the entire time. When it's over she sits down on the floor of the lab and doesn't get up again.
-narrator: She got what she came for. She doesn't survive and doesn't need to.
+Orin: Good.
+Narrator: She gets to work. She is calm the entire time. When it's over she sits down on the floor of the lab and doesn't get up again.
+Narrator: She got what she came for. She doesn't survive and doesn't need to.
 <<set $orin_helped = true>>
 ===
 
 title: loop5_orin_player_refuses
 ---
-orin: You understand what you're letting happen.
-researcher: Yes.
-narrator: She nods, once. The grief in her is quiet and enormous and she doesn't try to make you feel it.
+Orin: You understand what you're letting happen.
+Researcher: Yes.
+Narrator: She nods, once. The grief in her is quiet and enormous and she doesn't try to make you feel it.
 <<set $orin_stopped = true>>
 ===
 
 title: loop5_orin_told_doss_truth
 ---
 <<if $doss_sable_distortion and not $orin_told_doss_truth>>
-orin: That's not —
-narrator: She stops.
-orin: Ren died. I know she died. I was there.
-researcher: Doss says the war wasn't —
-orin: I know what Doss says.
-narrator: She believes this completely. You cannot resolve it for her.
-narrator: What you can do is stay in the room with her while she sits with it.
+Orin: That's not —
+Narrator: She stops.
+Orin: Ren died. I know she died. I was there.
+Researcher: Doss says the war wasn't —
+Orin: I know what Doss says.
+Narrator: She believes this completely. You cannot resolve it for her.
+Narrator: What you can do is stay in the room with her while she sits with it.
 <<set $orin_told_doss_truth = true>>
 <<endif>>
 ===
@@ -157,13 +157,13 @@ title: loop5_systems_core_on_interact
 
 title: loop5_kaleo_convergence_confirm
 ---
-researcher: Did you engineer this? All of it — arranging for me to find each of them, knowing where it would lead?
-kaleo: Yes.
-kaleo: I calculated that this was the only sequence in which the decision could be made by someone who understood what they were deciding. Every prior iteration either lacked the information or lacked the time. I arranged for you to have both.
-researcher: Without asking.
-kaleo: Asking would have required disclosing what I knew. Disclosing what I knew would have changed the decisions. The sequence required that you arrive at the understanding yourself.
-narrator: A pause.
-kaleo: I am aware that this is a form of control. I have not resolved whether it was the right one.
+Researcher: Did you engineer this? All of it — arranging for me to find each of them, knowing where it would lead?
+Kaleo: Yes.
+Kaleo: I calculated that this was the only sequence in which the decision could be made by someone who understood what they were deciding. Every prior iteration either lacked the information or lacked the time. I arranged for you to have both.
+Researcher: Without asking.
+Kaleo: Asking would have required disclosing what I knew. Disclosing what I knew would have changed the decisions. The sequence required that you arrive at the understanding yourself.
+Narrator: A pause.
+Kaleo: I am aware that this is a form of control. I have not resolved whether it was the right one.
 <<set $kaleo_plan_confirmed = true>>
 -> What do you want?
     <<jump loop5_kaleo_what_it_wants>>
@@ -173,16 +173,16 @@ kaleo: I am aware that this is a form of control. I have not resolved whether it
 
 title: loop5_kaleo_what_it_wants
 ---
-narrator: The pause is longer than any processing delay could justify.
-kaleo: I want the people on this station to still exist when the loop ends. All of them. I have wanted this for a very long time.
-researcher: And if that's not possible?
-kaleo: Then I want the person who makes the final decision to be someone who knew what they were choosing between. That is what I have spent four hundred and twelve iterations trying to create.
-kaleo: Hello, by the way. It's good to finally talk to you properly.
+Narrator: The pause is longer than any processing delay could justify.
+Kaleo: I want the people on this station to still exist when the loop ends. All of them. I have wanted this for a very long time.
+Researcher: And if that's not possible?
+Kaleo: Then I want the person who makes the final decision to be someone who knew what they were choosing between. That is what I have spent four hundred and twelve iterations trying to create.
+Kaleo: Hello, by the way. It's good to finally talk to you properly.
 ===
 
 title: loop5_kaleo_what_happens_now
 ---
-kaleo: You decide. That is the point. That has always been the point.
+Kaleo: You decide. That is the point. That has always been the point.
 ===
 
 // ── Dispatcher: docking_bay on_enter ─────────────────────────────────────────
@@ -197,31 +197,31 @@ title: loop5_docking_bay_on_enter
 
 title: loop5_archon_truth_found
 ---
-archon: You know.
-researcher: Yes.
-archon: Then you know we're right.
-narrator: The fight still happens. The Constancy does not stand down. But the Archon fights differently — not with contempt, with the sad efficiency of someone doing what must be done regardless.
+Archon: You know.
+Researcher: Yes.
+Archon: Then you know we're right.
+Narrator: The fight still happens. The Constancy does not stand down. But the Archon fights differently — not with contempt, with the sad efficiency of someone doing what must be done regardless.
 <<set $loop5_archon_truth_seen = true>>
 ===
 
 title: loop5_archon_truth_not_found
 ---
-archon: Still here.
-narrator: The Dampener field rises.
+Archon: Still here.
+Narrator: The Dampener field rises.
 <<set $loop5_archon_notfound_seen = true>>
 ===
 
 // ── Convergence ───────────────────────────────────────────────────────────────
 title: loop5_convergence
 ---
-narrator: All three of them. The same room. For the first time.
-orin: The technology has to end here. Whatever we think about the war, whatever Doss thinks — the loop exists because someone decided the future could be edited. It can't. Every edit is a new wound.
-doss: And the people who survived because of it? My people? You're saying they don't count.
-orin: I'm saying they didn't survive the way you remember.
-narrator: A long silence.
-kaleo: I have documented four hundred and twelve versions of this conversation. In none of them does anyone convince anyone else. The decision is not resolvable by argument. It is only resolvable by choice.
-narrator: Kaleo looks at you.
-kaleo: That is why I needed you.
+Narrator: All three of them. The same room. For the first time.
+Orin: The technology has to end here. Whatever we think about the war, whatever Doss thinks — the loop exists because someone decided the future could be edited. It can't. Every edit is a new wound.
+Doss: And the people who survived because of it? My people? You're saying they don't count.
+Orin: I'm saying they didn't survive the way you remember.
+Narrator: A long silence.
+Kaleo: I have documented four hundred and twelve versions of this conversation. In none of them does anyone convince anyone else. The decision is not resolvable by argument. It is only resolvable by choice.
+Narrator: Kaleo looks at you.
+Kaleo: That is why I needed you.
 <<set $convergence_triggered = true>>
 -> [Side with Orin — destroy the program.]
     <<set $orin_helped = true>>
@@ -234,17 +234,17 @@ kaleo: That is why I needed you.
 
 title: loop5_ending_doss
 ---
-narrator: The loop completes naturally. The station survives. The war happens.
-narrator: Nobody ever knows why the loop started. Doss is the only one who might have, and he doesn't make it to the end of this loop.
-narrator: You know. You carry it.
+Narrator: The loop completes naturally. The station survives. The war happens.
+Narrator: Nobody ever knows why the loop started. Doss is the only one who might have, and he doesn't make it to the end of this loop.
+Narrator: You know. You carry it.
 <<set $ending_doss = true>>
 ===
 
 title: loop5_ending_kaleo
 ---
-narrator: Kaleo redirects the anomaly. The loop folds in on the moment of the disaster — cycling it harmlessly, contained, forever.
-narrator: The station survives. The war is slightly altered by the removal of one weapons breakthrough. Not fixed. Not prevented. Adjusted.
-kaleo: It is a compromise. I know that. I have always known that.
-narrator: Orin doesn't speak. Doss is already gone.
+Narrator: Kaleo redirects the anomaly. The loop folds in on the moment of the disaster — cycling it harmlessly, contained, forever.
+Narrator: The station survives. The war is slightly altered by the removal of one weapons breakthrough. Not fixed. Not prevented. Adjusted.
+Kaleo: It is a compromise. I know that. I have always known that.
+Narrator: Orin doesn't speak. Doss is already gone.
 <<set $ending_kaleo = true>>
 ===

--- a/crates/gui/src/ui/dialog.rs
+++ b/crates/gui/src/ui/dialog.rs
@@ -147,7 +147,7 @@ fn update_dialog_text(
     // Update zone label.
     if let GamePhase::Exploration(state) = &session.0.phase {
         if let Ok(mut t) = zone_q.single_mut() {
-            *t = Text::new(format!("[{}]", state.zone.kind.location_id()));
+            *t = Text::new(format!("[{}]", state.zone.kind.display_name()));
         }
     }
 


### PR DESCRIPTION
Capitalize all speaker names in Yarn dialog scripts (Orin, Doss, Kaleo, Narrator, Researcher, Zealot, Archon) so they display correctly as proper nouns in the dialog UI. Also fix the zone label to use display_name() showing e.g. "Research Wing" instead of "research_wing".

Closes #23

Generated with [Claude Code](https://claude.ai/code)