### PR TITLE
fix: skip dead player actors mid-round to prevent stuck state

### DIFF
--- a/crates/core/src/combat.rs
+++ b/crates/core/src/combat.rs
@@ -148,6 +148,13 @@ impl BattleStep {
         if self.turn != Turn::Player || check_outcome(world).is_some() {
             return vec![];
         }
+        // Skip dead actors — they may have died mid-round from temporal effects.
+        while let Some(&front) = self.actor_queue.front() {
+            if world.get::<Health>(front).map(|h| h.is_alive()).unwrap_or(true) {
+                break;
+            }
+            self.actor_queue.pop_front();
+        }
         let actor = match self.actor_queue.front().copied() {
             Some(e) => e,
             None => return vec![],
@@ -196,7 +203,8 @@ impl BattleStep {
             .get::<ActionPoints>(actor)
             .map(|ap| ap.current)
             .unwrap_or(0);
-        let turn_ended = is_pass || ap_remaining == 0;
+        let actor_alive = world.get::<Health>(actor).map(|h| h.is_alive()).unwrap_or(false);
+        let turn_ended = is_pass || ap_remaining == 0 || !actor_alive;
 
         if turn_ended {
             self.actor_queue.pop_front();
@@ -458,6 +466,10 @@ impl BattleStep {
         }
 
         loop {
+            // Stop immediately if the actor died (e.g. from a TemporalCollapse).
+            if world.get::<Health>(actor).map(|h| !h.is_alive()).unwrap_or(false) {
+                break;
+            }
             let actor_turn = self.turn;
             match choose_action(world, actor, actor_turn) {
                 Some(Action::Pass) | None => break,

--- a/crates/core/tests/simulation_tests.rs
+++ b/crates/core/tests/simulation_tests.rs
@@ -2,8 +2,9 @@ use bevy::prelude::*;
 use carbonthrone::{
     action_points::ActionPoints,
     character::{Character, CharacterKind},
-    combat::{BattleOutcome, simulate_battle},
+    combat::{BattleOutcome, BattleStep, simulate_battle},
     health::Health,
+    player_input::PlayerActionChoice,
     position::Position,
     stats::Stats,
 };
@@ -97,4 +98,44 @@ fn faster_side_acts_first() {
 
     // Players always act first each round, so player kills enemy before taking damage
     assert_eq!(simulate_battle(&mut world), BattleOutcome::PlayerVictory);
+}
+
+/// Regression test: a player character that dies mid-round (while still in the
+/// actor queue with AP remaining) must not block the queue or act after death.
+/// The battle should detect defeat once all players are dead.
+#[test]
+fn dead_player_mid_round_does_not_get_choices() {
+    let mut world = World::new();
+    // Two players. Player A will be killed manually mid-round.
+    let player_a = player(&mut world, 10, 5, 2, 10);
+    let player_b = player(&mut world, 10, 5, 2, 8);
+    // One enemy with plenty of HP so the battle doesn't end from player attacks.
+    enemy(&mut world, 1000, 1, 50, 1);
+
+    let mut battle = BattleStep::new(&mut world);
+
+    // It should be the player turn.
+    assert_eq!(battle.turn, carbonthrone::combat::Turn::Player);
+
+    // Kill player A directly — simulating death from a mid-round temporal effect.
+    if let Some(mut h) = world.get_mut::<Health>(player_a) {
+        h.take_damage(1000);
+    }
+
+    // player_choices must skip the dead player A and return choices for B.
+    let choices = battle.player_choices(&mut world);
+    // There should still be choices (B is alive and enemies exist).
+    assert!(!choices.is_empty(), "live player B should still have choices");
+    // Passing for B ends B's turn; both players have acted (A was dead/skipped).
+    let result = battle.step_player_action(&mut world, &PlayerActionChoice::Pass);
+    assert!(result.turn_ended);
+
+    // Kill player B as well.
+    if let Some(mut h) = world.get_mut::<Health>(player_b) {
+        h.take_damage(1000);
+    }
+
+    // Now all players are dead; player_choices must return empty.
+    let choices = battle.player_choices(&mut world);
+    assert!(choices.is_empty(), "no choices expected when all players are dead");
 }


### PR DESCRIPTION
Fixes #33

When a player character dies mid-turn from a TemporalCollapse triggered by their own ability, they remained in the actor queue with AP remaining. This caused dead characters to receive choices in the GUI or continue acting in the CLI.

Three fixes in `BattleStep`: skip dead actors in `player_choices`, end turn immediately on actor death in `step_player_action`, and break the action loop on actor death in `step`.

Generated with [Claude Code](https://claude.ai/code)